### PR TITLE
.tap that path

### DIFF
--- a/lib/install/install.rb
+++ b/lib/install/install.rb
@@ -23,7 +23,7 @@ say "Configure importmap paths in config/initializers/assets.rb"
 append_to_file Rails.root.join("config/initializers/assets.rb") do <<-RUBY
 
 # Configure importmap paths in addition to having all files in app/assets/javascripts mapped.
-Rails.application.config.importmap.paths do |paths|
+Rails.application.config.importmap.paths.tap do |paths|
   # Match libraries with their NPM package names for possibility of easy later porting.
   # Ensure that libraries listed in the path have been linked in the asset pipeline manifest or precompiled.
   paths.asset "@rails/actioncable", path: "actioncable.esm.js"


### PR DESCRIPTION
The `lib/install/install.rb` script is missing `.tap` in the append to `config/initializers/assets.rb` file and so does actually set any of the passed assets/directories. The tests did not pick up on this, because the dummy app correctly uses .tap in it.

Thanks again for blazing the trail on ESM and Rails! Love that it's been extracted to a separate repo :)