### PR TITLE
Append asset path with file type if not provided

### DIFF
--- a/lib/importmap/paths.rb
+++ b/lib/importmap/paths.rb
@@ -8,6 +8,7 @@ class Importmap::Paths
 
   def asset(name, path: nil)
     @files[name] = path || "#{name}.js"
+    @files[name] += '.js' unless @files[name].ends_with?('.js')
   end
 
   def assets_in(path, append_base_path: false)


### PR DESCRIPTION
I'm not sure if this is the best way to solve this problem, but it seemed like an ok proposition. 

Both the turbo-rails and stimulus-rails projects declare their import maps via `paths.asset "@hotwired/turbo-rails", path: "turbo"` (without the file extension).

This ends up breaking precompiled assets because it cannot find the asset `turbo`. 

A simple way to check this is via `ActionController::Base.helpers.asset_path 'turbo'` which will throw an error. Calling `ActionController::Base.helpers.asset_path 'turbo.js'` will resolve correctly.

As I see it, the asset declaration here is already adding the extension to the name, so maybe it makes sense to always check for the `.js` extension? Otherwise I believe the other 2 repos will need to be updated to set those extensions.

