### PR TITLE
Add load_path to pin_all_from to support different nesting directories

### DIFF
--- a/test/dummy/app/assets/javascripts/plugin/controllers/plugin_controller.js
+++ b/test/dummy/app/assets/javascripts/plugin/controllers/plugin_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from "stimulus"
+
+export default class extends Controller {
+  connect() {
+    this.element.textContent = "Hello Plugin"
+  }
+}

--- a/test/importmap_test.rb
+++ b/test/importmap_test.rb
@@ -10,6 +10,7 @@ class ImportmapTest < ActiveSupport::TestCase
         pin "md5", to: "https://cdn.skypack.dev/md5", preload: true
 
         pin_all_from "app/assets/javascripts/controllers", under: "controllers", preload: true
+        pin_all_from "app/assets/javascripts/plugin/controllers", under: "controllers", load_path: "app/assets/javascripts"
       end
     end
   end
@@ -32,6 +33,10 @@ class ImportmapTest < ActiveSupport::TestCase
 
   test "directory pin mounted under matching subdir maps all files" do
     assert_match %r|assets/controllers/goodbye_controller-.*\.js|, generate_importmap_json["imports"]["controllers/goodbye_controller"]
+  end
+  
+  test "directory pin mounted under different subdir maps all files" do
+    assert_match %r|assets/plugin/controllers/plugin_controller-.*\.js|, generate_importmap_json["imports"]["controllers/plugin_controller"]
   end
 
   test "directory pin mounted under matching subdir maps index as root" do


### PR DESCRIPTION
First of all: I'm extremely excited about Rails' new direction with importmaps. Using Webpacker inside Rails engines was borderline impossible. This new setup with importmaps enables us to ship modern javascript in engines far easier than before. 

For [Spina CMS](https://github.com/spinacms/spina), I've created a separate importmap for the admin interface (to not interfere with the main app's importmap). The current version of importmap-rails doesn't allow a lot of control over the generated paths in `pin_all_from`. In order to fix #6 I added a new option `load_path`. 

Specifying the `load_path` enables us to generate paths to assets that live in a different directory than would be assumed by the `under` attribute.

Example:
```ruby
pin_all_from Spina::Engine.root.join("app/assets/javascripts/spina/controllers"), under: "controllers", load_path: Spina::Engine.root.join("app/assets/javascripts")
```

Will generate:
`"controllers/some-controller.js": "/assets/spina/controllers/some-controller.js"`

I'm not sure if this is the correct approach. I'd love to get feedback ✌️