### PR TITLE
Commented path sample for vendored modules was one level too deep.

### DIFF
--- a/lib/install/install.rb
+++ b/lib/install/install.rb
@@ -9,7 +9,7 @@ else
 end
 
 say "Create application.js module as entrypoint"
-create_file Rails.root.join("app/javascript/application.js") do <<-JS
+create_file Rails.root.join("app/javascripts/application.js") do <<-JS
 // Configure your import map in config/initializers/importmap.rb
 
 // import "@rails/actioncable"
@@ -34,7 +34,7 @@ Rails.application.config.importmap.draw do
   # pin "d3", to: "https://esm.sh/d3?bundle"
 
   # Pin vendored modules by first adding the following to app/assets/config/manifest.js:
-  # //= link_tree ../../../vendor/assets/javascripts .js
+  # //= link_tree ../../vendor/assets/javascripts .js
   # pin_all_from "vendor/assets/javascripts"
 end
 RUBY


### PR DESCRIPTION
Similar to 0fc4aacfcce316c1a8f2dc73a72101e31f2b02b5, the documented path for vendored assets has one step too many.