### PR TITLE
Fix Reloader CI failure

### DIFF
--- a/test/reloader_test.rb
+++ b/test/reloader_test.rb
@@ -30,5 +30,6 @@ class ReloaderTest < ActiveSupport::TestCase
   private
     def touch_config
       FileUtils.touch(@config)
+      sleep 1
     end
 end


### PR DESCRIPTION
Looks like this maybe a linux thing. Everything passes fine on my mac but looks like the tests in Rails around the FileUpdateChecker also use `sleep 1` to ensure there's a new mtime.