### PR TITLE
Stop adding a leading slash to filenames

### DIFF
--- a/lib/importmap/map.rb
+++ b/lib/importmap/map.rb
@@ -80,7 +80,7 @@ class Importmap::Map
     end
 
     def module_path_from(filename, mapping)
-      [ mapping.path || mapping.under, filename.to_s ].join("/")
+      [ mapping.path || mapping.under, filename.to_s ].compact.join("/")
     end
 
     def find_javascript_files_in_tree(path)

--- a/test/importmap_test.rb
+++ b/test/importmap_test.rb
@@ -14,6 +14,7 @@ class ImportmapTest < ActiveSupport::TestCase
         pin_all_from "app/javascript/spina/controllers", under: "controllers/spina"
         pin_all_from "app/javascript/spina/controllers", under: "controllers/spina", to: "spina/controllers"
         pin_all_from "app/javascript/helpers", under: "helpers"
+        pin_all_from "lib/assets/javascripts"
       end
     end
   end
@@ -50,6 +51,10 @@ class ImportmapTest < ActiveSupport::TestCase
   test "directory pin under custom asset path" do
     assert_match %r|assets/spina/controllers/another_controller-.*\.js|, generate_importmap_json["imports"]["controllers/spina/another_controller"]
     assert_match %r|assets/spina/controllers/deeper/again_controller-.*\.js|, generate_importmap_json["imports"]["controllers/spina/deeper/again_controller"]
+  end
+
+  test "directory pin without path or under" do
+    assert_match %r|assets/my_lib-.*\.js|, generate_importmap_json["imports"]["my_lib"]
   end
 
   test "preloaded modules are included in preload tags" do


### PR DESCRIPTION
The `config/importmap.rb` that gets generated [invites you to map all your vendor assets](https://github.com/rails/importmap-rails/blob/main/lib/install/install.rb#L36-L38). It doesn’t actually work as advertised. The problem is, when you have a directory pinned without specifying `to:` or `under:`, the paths resolved for the files have a leading slash. `my_lib` becomes `/my_lib`. You then end up with a request to `app.test/my_lib.js`, which obviously doesn’t work. Sprockets won’t do anything with the path — doesn’t transform it, doesn’t complain — so we don’t even get [the warning](https://github.com/rails/importmap-rails/blob/main/lib/importmap/map.rb#L49-L50) you normally do when you ask for a path to a non-existent file.

This fixes all that.