### PR TITLE
Fix warning message in importmap tags helper

### DIFF
--- a/app/helpers/importmap/importmap_tags_helper.rb
+++ b/app/helpers/importmap/importmap_tags_helper.rb
@@ -29,7 +29,7 @@ module Importmap::ImportmapTagsHelper
   # (defaults to Rails.application.config.importmap), such that they'll be fetched
   # in advance by browsers supporting this link type (https://caniuse.com/?search=modulepreload).
   def javascript_importmap_module_preload_tags(importmap = Rails.application.config.importmap)
-    javascript_module_preload_tag *importmap.preloaded_module_paths(resolver: self)
+    javascript_module_preload_tag(*importmap.preloaded_module_paths(resolver: self))
   end
 
   # Link tag(s) for preloading the JavaScript module residing in `*paths`. Will return one link tag per path element.


### PR DESCRIPTION
Using the splat operator as a method argument without parentheses throw a warning `'*' interpreted as argument prefix`
https://buildkite.com/rails/rails/builds/80621#ba67a8c1-b5e6-42de-9b27-38e63e9356d3

Fixes #15