### PR TITLE
Remove dependency on httparty

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     importmap-rails (0.5.0)
-      httparty (>= 0.16)
       rails (>= 6.0.0)
 
 GEM
@@ -85,9 +84,6 @@ GEM
     erubi (1.10.0)
     globalid (0.5.1)
       activesupport (>= 5.0)
-    httparty (0.18.1)
-      mime-types (~> 3.0)
-      multi_xml (>= 0.5.2)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     loofah (2.10.0)
@@ -97,12 +93,8 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.1)
     method_source (1.0.0)
-    mime-types (3.3.1)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2021.0704)
     mini_mime (1.0.3)
     minitest (5.14.4)
-    multi_xml (0.6.0)
     nio4r (2.5.7)
     nokogiri (1.11.7-arm64-darwin)
       racc (~> 1.4)

--- a/importmap-rails.gemspec
+++ b/importmap-rails.gemspec
@@ -15,5 +15,4 @@ Gem::Specification.new do |spec|
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
   spec.add_dependency "rails", ">= 6.0.0"
-  spec.add_dependency "httparty", ">= 0.16"
 end

--- a/lib/importmap/packager.rb
+++ b/lib/importmap/packager.rb
@@ -1,26 +1,39 @@
-require "httparty"
+require "net/http"
+require "uri"
+require "json"
 require "minitest/mock"
 
 class Importmap::Packager
-  include HTTParty
-  base_uri "https://api.jspm.io"
+  Error = Class.new(StandardError)
+  HTTPError = Class.new(Error)
+  ServiceError = Error.new(Error)
+
+  singleton_class.attr_accessor :endpoint
+  self.endpoint = URI("https://api.jspm.io/generate")
 
   def initialize(importmap_path = "config/importmap.rb")
     @importmap_path = importmap_path
   end
 
   def import(*packages, env: "production", from: "jspm")
-    response = self.class.post("/generate", body: {
+    response = post_json({
       "install"      => Array(packages), 
       "flattenScope" => true,
       "env"          => [ "browser", "module", env ],
-      "provider"     => from.to_s
-    }.to_json)
-    
+      "provider"     => from.to_s,
+    })
+
     case response.code
-    when 200 then response.dig("map", "imports")
-    when 404 then nil
-    else          response.send(:throw_exception)
+    when "200"
+      JSON.parse(response.body).dig("map", "imports")
+    when "404", "401" # 401 is returned on package not found
+      nil
+    else
+      if error_message = parse_service_error(response)
+        raise ServiceError, error_message
+      else
+        raise HTTPError, "Unexpected response code (#{response.code})"
+      end
     end
   end
 
@@ -33,6 +46,29 @@ class Importmap::Packager
   end
 
   private
+    def parse_service_error(response)
+      return unless response.body
+
+      json_error = begin
+        JSON.parse(response.body)
+      rescue JSON::ParserError
+        return
+      end
+
+      return unless json_error.is_a?(Hash)
+      json_error["error"]
+    end
+
+    def post_json(body)
+      json_body = body.to_json
+
+      begin
+        Net::HTTP.post(self.class.endpoint, json_body, { "Content-Type" => "application/json" })
+      rescue => error
+        raise HTTPError, "Unexpected transport error (#{error.class}: #{error.message})"
+      end
+    end
+
     def importmap
       @importmap ||= File.read(@importmap_path)
     end

--- a/test/packager_integration_test.rb
+++ b/test/packager_integration_test.rb
@@ -13,12 +13,13 @@ class Importmap::PackagerIntegrationTest < ActiveSupport::TestCase
   end
 
   test "failed request against live bad domain" do
-    Importmap::Packager.base_uri "https://this-is-not-a-real-url.com"
+    original_endpoint = Importmap::Packager.endpoint
+    Importmap::Packager.endpoint = URI("https://invalid./error")
 
-    assert_raises(SocketError) do
+    assert_raises(Importmap::Packager::HTTPError) do
       @packager.import("missing-package-that-doesnt-exist@17.0.2")
     end
   ensure
-    Importmap::Packager.base_uri "https://api.jspm.io"
+    Importmap::Packager.endpoint = original_endpoint
   end
 end

--- a/test/packager_test.rb
+++ b/test/packager_test.rb
@@ -1,5 +1,6 @@
 require "test_helper"
 require "importmap/packager"
+require "minitest/mock"
 
 class Importmap::PackagerTest < ActiveSupport::TestCase
   setup { @packager = Importmap::Packager.new(Rails.root.join("config/importmap.rb")) }

--- a/test/packager_test.rb
+++ b/test/packager_test.rb
@@ -6,6 +6,10 @@ class Importmap::PackagerTest < ActiveSupport::TestCase
 
   test "successful import with mock" do
     response = Class.new do
+      def body
+        { "map" => { "imports" => imports } }.to_json
+      end
+
       def imports
         {
           "react" => "https://ga.jspm.io/npm:react@17.0.2/index.js",
@@ -13,31 +17,29 @@ class Importmap::PackagerTest < ActiveSupport::TestCase
         }
       end
 
-      def code() 200 end
-      def dig(*args) imports end
+      def code() "200" end
     end.new
 
-    @packager.class.stub(:post, response) do
+    @packager.stub(:post_json, response) do
       assert_equal(response.imports, @packager.import("react@17.0.2"))
     end
   end
 
   test "missing import with mock" do
-    response = Class.new { def code() 404 end }.new
+    response = Class.new { def code() "404" end }.new
 
-    @packager.class.stub(:post, response) do
+    @packager.stub(:post_json, response) do
       assert_nil @packager.import("missing-package-that-doesnt-exist@17.0.2")
     end
   end
 
   test "failed request with mock" do
     response = Class.new do
-      def code() 500 end
-      def throw_exception() raise HTTParty::ResponseError.new({}) end
+      def code() "500" end
     end.new
 
-    @packager.class.stub(:post, response) do
-      assert_raises(HTTParty::ResponseError) do
+    Net::HTTP.stub(:post, proc { raise "Unexpected Error" }) do
+      assert_raises(Importmap::Packager::HTTPError) do
         @packager.import("missing-package-that-doesnt-exist@17.0.2")
       end
     end


### PR DESCRIPTION
That's quite a lot of dependencies for a single HTTP POST.
Net::HTTP is a little clunkier to use, but it does the job fine.

