### PR TITLE
allow to use `__dir__` in `importmap.rb` files

### DIFF
--- a/lib/importmap/map.rb
+++ b/lib/importmap/map.rb
@@ -11,7 +11,7 @@ class Importmap::Map
   def draw(path = nil, &block)
     if path && File.exist?(path)
       begin
-        instance_eval(File.read(path))
+        instance_eval(File.read(path), path.to_s)
       rescue Exception => e
         Rails.logger.error "Unable to parse import map from #{path}: #{e.message}"
         raise "Unable to parse import map from #{path}: #{e.message}"


### PR DESCRIPTION
A minor tweak to `instance_eval` in the `draw` method, which allows the use of `__dir__` (and similar) in `importmap.rb`.

Useful when composing importmaps, for example from Rails Engines:

```ruby
# engine.rb

initializer "importmap" do |app|
  app.config.importmap.draw(Engine.root.join("config/importmap.rb"))
end
```

```ruby
# importmap.rb

pin_all_from File.expand_path("../app/assets/javascripts", __dir__)
```