### PR TITLE
Enable cache in test environment by default

### DIFF
--- a/lib/importmap/engine.rb
+++ b/lib/importmap/engine.rb
@@ -30,7 +30,7 @@ module Importmap
 
     initializer "importmap.caching" do |app|
       if Rails.application.config.importmap.cached.nil?
-        Rails.application.config.importmap.cached = app.config.action_controller.perform_caching
+        Rails.application.config.importmap.cached = Rails.env.test? || app.config.action_controller.perform_caching
       end
     end
   end


### PR DESCRIPTION
This change enables caching by default in `test` environments, and keeps the previous `config.action_controller.perform_caching` default otherwise.

Having the cache disabled has a noticeable performance impact on every request made in integration and system tests.

For example, for HEY:

```ruby
>> Benchmark.measure { helper.javascript_importmap_tags }.real
=> 1.6442509999906179
>> Benchmark.measure { helper.javascript_importmap_tags }.real
=> 0.3669999999983702
```

Versus:

```ruby
>> Rails.application.config.importmap.cached = true
>> Benchmark.measure { helper.javascript_importmap_tags }.real
=> 1.6328830000129528
>> Benchmark.measure { helper.javascript_importmap_tags }.real
=> 0.003431999997701496
```

cc @dhh 