### PR TITLE
Fix broken `bin/importmap json` command

### DIFF
--- a/lib/importmap/commands.rb
+++ b/lib/importmap/commands.rb
@@ -43,6 +43,7 @@ class Importmap::Commands < Thor
 
   desc "json", "Show the full importmap in json"
   def json
+    require Rails.root.join("config/environment")
     puts Rails.application.importmap.to_json(resolver: ActionController::Base.helpers)
   end
 


### PR DESCRIPTION
Fixes #38

This command is supposed to print the importmap JSON, but it has been printing `null` since 75f312b21eebe31b5d9411ceac7c8cdb93e1ee5d because that commit delayed the construction of the `Importmap::Map` instance. It was previously constructed at class-evaluation-time (i.e. as soon as `importmap/engine.rb` was loaded), but now it's constructed in an initializer:
https://github.com/rails/importmap-rails/commit/75f312b21eebe31b5d9411ceac7c8cdb93e1ee5d#diff-5dac3d58ec92e0c2cba54981b8ff708a46dd3650b323dcfd9edccb25aac48ff1

In other words, loading `config/application.rb`, like we do here:
https://github.com/rails/importmap-rails/blob/7aa75e4f6fee00178167ec45b276d2f09fd2fe85/lib/install/bin/importmap#L3
used to be enough to use `Rails.application.config.importmap`, but it's no longer sufficient to be able to use `Rails.application.importmap` - that'll be `nil` until the application's initializers have been executed.

To fix this, we're explicitly requiring `config/environment.rb` ([which calls `Rails.application.initialize!` to run the initializers][1]) before we reference the importmap to print its JSON.

An alternative solution would be to change `bin/importmap` to require `config/environment` rather than `config/application`, but that would introduce unnecessary overhead when running the `pin` and `unpin` commands, which do not require the initializers to have been executed (they do not reference the `Rails.application.importmap` instance). Additionally, it'd require updating the `importmap` binstubs that were already generated on older versions of importmap-rails.

[1]: https://github.com/rails/rails/blob/014347620db4b063e63caf3914f1737cd87bf5d5/railties/lib/rails/generators/rails/app/templates/config/environment.rb.tt#L5