### PR TITLE
Add a step to check the `bin/importmap json` command on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,8 @@ jobs:
       - name: Run tests
         run: |
           bundle exec rake
+
+      - name: Ensure json command prints an importmap
+        run: |
+          cp lib/install/bin/importmap test/dummy/bin/importmap
+          test/dummy/bin/importmap json | jq -e .imports


### PR DESCRIPTION
This is a follow-up to #39 which fixed a bug in the `bin/importmap json` command: we're adding a minor check to CI to verify that the command prints a JSON object containing `imports`.