### PR TITLE
Remove `importmap:pins` rake task in favor of `bin/importmap json` CLI

### DIFF
--- a/lib/tasks/importmap_tasks.rake
+++ b/lib/tasks/importmap_tasks.rake
@@ -3,10 +3,4 @@ namespace :importmap do
   task :install do
     system "#{RbConfig.ruby} ./bin/rails app:template LOCATION=#{File.expand_path("../install/install.rb",  __dir__)}"
   end
-
-  desc "Show the importmap"
-  task :pins do
-    require Rails.root.join("config/environment")
-    puts Rails.application.importmap.to_json(resolver: ActionController::Base.helpers)
-  end
 end


### PR DESCRIPTION
The `importmap:pins` rake task was added in f42f53e91bae9324a1a6f85e0bc03914ca372b03 before the `bin/importmap` CLI existed. Its function is identical to the `bin/importmap json` command, though, so I'm proposing we remove the rake task in an effort to consolidate around just the `bin/importmap` CLI (which also hosts the `pin` and `unpin` commands).