### PR TITLE
Avoid mentioning "node" in importmap.rb template and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ It's in `app/javascript/application.js` you setup your application by importing 
 It makes sense to use logical names that match the package names used by npm, such that if you later want to start transpiling or bundling your code, you won't have to change any module imports.
 
 
-## Using node modules via JavaScript CDNs
+## Using npm packages via JavaScript CDNs
 
-Importmap for Rails is designed to be used with JavaScript CDNs for your node package dependencies. The CDNs provide pre-compiled distribution versions ready to use, and offer a fast, efficient way of serving them.
+Importmap for Rails is designed to be used with JavaScript CDNs for your npm package dependencies. The CDNs provide pre-compiled distribution versions ready to use, and offer a fast, efficient way of serving them.
 
-You can use the `./bin/importmap` command that's added as part of the install to pin, unpin, or update node packages in your import map. This command uses an API from [JSPM.org](https://jspm.org) to resolve your package dependencies efficiently, and then add the pins to your `config/importmap.rb` file. It can resolve these dependencies from JSPM itself, but also from other CDNs, like [unpkg.com](https://unpkg.com) and [jsdelivr.com](https://www.jsdelivr.com).
+You can use the `./bin/importmap` command that's added as part of the install to pin, unpin, or update npm packages in your import map. This command uses an API from [JSPM.org](https://jspm.org) to resolve your package dependencies efficiently, and then add the pins to your `config/importmap.rb` file. It can resolve these dependencies from JSPM itself, but also from other CDNs, like [unpkg.com](https://unpkg.com) and [jsdelivr.com](https://www.jsdelivr.com).
 
 It works like so:
 

--- a/lib/install/config/importmap.rb
+++ b/lib/install/config/importmap.rb
@@ -1,6 +1,6 @@
 # Use direct uploads for Active Storage (remember to import "@rails/activestorage" in your application.js)
 # pin "@rails/activestorage", to: "activestorage.esm.js"
 
-# Use node modules from a JavaScript CDN by running ./bin/importmap
+# Use npm packages from a JavaScript CDN by running ./bin/importmap
 
 pin "application"


### PR DESCRIPTION
Given that a major benefit of using the default importmap-rails approach is that you don't need nodejs at all, I think we should avoid using the term "node modules" and instead use "npm packages". This should hopefully avoid confusion/misunderstanding where folks mistakenly think they still need to install node: The CDNs allow them to still leverage the npm ecosystem even if their system doesn't have nodejs nor any local `node_modules` directories.