### PR TITLE
docs: note Firefox asm.js warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Generating the import map json and modulepreloads may require resolving hundreds
 
 While import maps are native in Chrome and Edge, they need a shim in other browsers that'll produce a JavaScript console error like `TypeError: Module specifier, 'application' does not start with "/", "./", or "../".`. This error is normal and does not have any user-facing consequences.
 
+In Firefox. when opening the browser console, the asm.js module lexer build will run in unoptimized mode due to the debugger attaching. This gives a warning message `"asm.js type error: Disabled because no suitable wasm compiler is available"` which is as expected. When the console is closed again, the asm.js optimizations are fully applied, and this can even be verified with the console open by disabling the debugger in `about:config` and reloading the page.
 
 ## Turning off the shim
 


### PR DESCRIPTION
Adds the docs clarifications from https://github.com/rails/importmap-rails/issues/46.