### PR TITLE
Print the actual vendor path for the package when pinning

### DIFF
--- a/lib/importmap/commands.rb
+++ b/lib/importmap/commands.rb
@@ -16,7 +16,7 @@ class Importmap::Commands < Thor
     if imports = packager.import(*packages, env: options[:env], from: options[:from])
       imports.each do |package, url|
         if options[:download]
-          puts %(Pinning "#{package}" to vendor/#{package}.js via download from #{url})
+          puts %(Pinning "#{package}" to #{packager.vendor_path}/#{package}.js via download from #{url})
           packager.download(package, url)
           pin = packager.vendored_pin_for(package, url)
         else

--- a/lib/importmap/packager.rb
+++ b/lib/importmap/packager.rb
@@ -10,6 +10,8 @@ class Importmap::Packager
   singleton_class.attr_accessor :endpoint
   self.endpoint = URI("https://api.jspm.io/generate")
 
+  attr_reader :vendor_path
+
   def initialize(importmap_path = "config/importmap.rb", vendor_path: "vendor/javascript")
     @importmap_path = Pathname.new(importmap_path)
     @vendor_path    = Pathname.new(vendor_path)


### PR DESCRIPTION
Before this it was printing `Pinning "foo" to vendor/foo.js via download from …`, now that is `Pinning "foo" to vendor/javascript/foo.js via download from …` which reflects the actual location.