### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,11 @@ module MyEngine
     initializer "my-engine.importmap", after: "importmap" do |app|
       app.importmap.draw(Engine.root.join("config/importmap.rb"))
     end
+    
+    # If using Rails version < 7 and engine uses the newer app/javascript path for javascript assets
+    initializer "my-engine.importmap.assets" do |app|
+      Rails.application.config.assets.paths << Engine.root.join("app/javascript")
+    end
   end
 end
 ```


### PR DESCRIPTION
Hello!

I'm not sure if my engine was setup incorrectly (I'm new to working with engines and tried my best to follow the documentation), but the README was missing an initializer I needed to get my engine to work. 

The issue could be I'm running on Rails 6.1.4 on my test project, and it is using the original app/assets/javascripts path. Perhaps this won't be an issue for newer Rails 7 apps since I assume they will already be configured to include app/javascript as a default asset path.

Either way, I thought I would throw this out there. I understand if this doesn't actually belongs in the README for this gem due to it potentially being an unrelated configuration error on my part.