### PR TITLE
Decouple from sprockets-rails

### DIFF
--- a/lib/importmap/engine.rb
+++ b/lib/importmap/engine.rb
@@ -7,6 +7,7 @@ module Importmap
   class Engine < ::Rails::Engine
     config.importmap = ActiveSupport::OrderedOptions.new
     config.importmap.sweep_cache = Rails.env.development? || Rails.env.test?
+    config.importmap.rescuable_asset_errors = []
 
     config.autoload_once_paths = %W( #{root}/app/helpers )
 
@@ -47,6 +48,12 @@ module Importmap
     initializer "importmap.helpers" do
       ActiveSupport.on_load(:action_controller_base) do
         helper Importmap::ImportmapTagsHelper
+      end
+    end
+
+    initializer 'importmap.rescuable_asset_errors' do |app|
+      if defined?(Sprockets::Rails)
+        app.config.importmap.rescuable_asset_errors << Sprockets::Rails::Helper::AssetNotFound
       end
     end
   end

--- a/lib/importmap/map.rb
+++ b/lib/importmap/map.rb
@@ -88,7 +88,7 @@ class Importmap::Map
     end
 
     def rescuable_asset_error?(error)
-      error.is_a?(Sprockets::Rails::Helper::AssetNotFound)
+      Rails.application.config.importmap.rescuable_asset_errors.any? { |e| error.is_a?(e) }
     end
 
     def resolve_asset_paths(paths, resolver:)

--- a/lib/importmap/map.rb
+++ b/lib/importmap/map.rb
@@ -87,13 +87,21 @@ class Importmap::Map
       @cached_preloaded_module_paths = nil
     end
 
+    def rescuable_asset_error?(error)
+      error.is_a?(Sprockets::Rails::Helper::AssetNotFound)
+    end
+
     def resolve_asset_paths(paths, resolver:)
       paths.transform_values do |mapping|
         begin
           resolver.asset_path(mapping.path)
-        rescue Sprockets::Rails::Helper::AssetNotFound
-          Rails.logger.warn "Importmap skipped missing path: #{mapping.path}"
-          nil
+        rescue => e
+          if rescuable_asset_error?(e)
+            Rails.logger.warn "Importmap skipped missing path: #{mapping.path}"
+            nil
+          else
+            raise e
+          end
         end
       end.compact
     end


### PR DESCRIPTION
As noted in https://github.com/rails/importmap-rails/issues/42, the gem had a direct reference to a constant from sprockets-rails here:
https://github.com/rails/importmap-rails/blob/8d66a09efa9e5d43f7f2e5150b0ccb45c08a8220/lib/importmap/map.rb#L94

This is problematic because consumers may be using a different asset pipeline than sprockets-rails. In that case, when `Importmap::Map#resolve_asset_paths` invokes the application's `asset_path` helper method, it may need to rescue different exceptions than `Sprockets::Rails::Helper::AssetNotFound`.

To support that, we've added a `rescuable_asset_errors` property to the importmap configuration options. We automatically add `Sprockets::Rails::Helper::AssetNotFound` to the list if `Sprockets::Rails` is defined, which should allow the gem to work the same as before in applications that use sprockets-rails. But now it'll also be usable in applications that use something other than sprockets-rails.