### PR TITLE
docs: explain "why" importmaps + how they work.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Note: In order to use JavaScript from Rails frameworks like Action Cable, Action
 
 At their core, importmaps are essentially a string substitution for what are referred to as "bare module specifiers". A "bare module specifier" looks like this: `import React from "react"`. This is not compatible with the ES Module loader spec. Instead, to be ESM compatible, you must provide 1 of the 3 following types of specifiers:
 
-A.) Absolute path `import React from "/Users/DHH/projects/basecamp/node_modules/react"`
-B.) Relative path `import React from "./node_modules/react"`
-C.) HTTP path: `import React from "https://ga.jspm.io/npm:react@17.0.1/index.js"`
+- Absolute path `import React from "/Users/DHH/projects/basecamp/node_modules/react"`
+- Relative path `import React from "./node_modules/react"`
+- HTTP path: `import React from "https://ga.jspm.io/npm:react@17.0.1/index.js"`
 
 Importmap-rails provides a clean API for mapping "bare module specifiers" like `"react"` to 1 of the 3 viable ways of loading ES Module javascript packages.
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,29 @@ Importmap for Rails is automatically included in Rails 7+ for new applications, 
 
 Note: In order to use JavaScript from Rails frameworks like Action Cable, Action Text, and Active Storage, you must be running Rails 7.0+. This was the first version that shipped with ESM compatible builds of these libraries.
 
+## How do importmaps work?
+
+At their core, importmaps are essentially a string substitution for what are referred to as "bare module specifiers". A "bare module specifier" looks like this: `import React from "react"`. This is not compatible with the ES Module loader spec. Instead, to be ESM compatible, you must provide 1 of the 3 following types of specifiers:
+
+A.) Absolute path `import React from "/Users/DHH/projects/basecamp/node_modules/react"`
+B.) Relative path `import React from "./node_modules/react"`
+C.) HTTP path: `import React from "https://ga.jspm.io/npm:react@17.0.1/index.js"`
+
+Importmap-rails provides a clean API for mapping "bare module specifiers" like `"react"` to 1 of the 3 viable ways of loading ES Module javascript packages.
+
+For example:
+
+```rb
+// config/importmaps.rb
+pin "react" to "https://ga.jspm.io/npm:react@17.0.2/index.js"
+```
+
+means "everytime you see `import React from "react"` change it to `import React from "https://ga.jspm.io/npm:react@17.0.2/index.js"`"
+
+```js
+import React from "react" 
+// => import React from "https://ga.jspm.io/npm:react@17.0.2/index.js"
+```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Importmap-rails provides a clean API for mapping "bare module specifiers" like `
 For example:
 
 ```rb
-// config/importmaps.rb
+# config/importmaps.rb
 pin "react" to "https://ga.jspm.io/npm:react@17.0.2/index.js"
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,11 +21,23 @@ Note: In order to use JavaScript from Rails frameworks like Action Cable, Action
 
 At their core, importmaps are essentially a string substitution for what are referred to as "bare module specifiers". A "bare module specifier" looks like this: `import React from "react"`. This is not compatible with the ES Module loader spec. Instead, to be ESM compatible, you must provide 1 of the 3 following types of specifiers:
 
-- Absolute path `import React from "/Users/DHH/projects/basecamp/node_modules/react"`
-- Relative path `import React from "./node_modules/react"`
-- HTTP path: `import React from "https://ga.jspm.io/npm:react@17.0.1/index.js"`
+- Absolute path:
+```js
+import React from "/Users/DHH/projects/basecamp/node_modules/react"
+```
 
-Importmap-rails provides a clean API for mapping "bare module specifiers" like `"react"` to 1 of the 3 viable ways of loading ES Module javascript packages.
+- Relative path:
+```js
+import React from "./node_modules/react"
+```
+
+- HTTP path:
+```js
+import React from "https://ga.jspm.io/npm:react@17.0.1/index.js"
+```
+
+Importmap-rails provides a clean API for mapping "bare module specifiers" like `"react"` 
+to 1 of the 3 viable ways of loading ES Module javascript packages.
 
 For example:
 
@@ -34,7 +46,8 @@ For example:
 pin "react" to "https://ga.jspm.io/npm:react@17.0.2/index.js"
 ```
 
-means "everytime you see `import React from "react"` change it to `import React from "https://ga.jspm.io/npm:react@17.0.2/index.js"`"
+means "everytime you see `import React from "react"` 
+change it to `import React from "https://ga.jspm.io/npm:react@17.0.2/index.js"`"
 
 ```js
 import React from "react" 


### PR DESCRIPTION
## Why?

with importmaps being the default in Rails 7, I think it's important for those not familiar with importmaps to have a brief description of what importmaps are and how they work without having to visit external resources.