### PR TITLE
Fix reference to renamed pin/unpin option

### DIFF
--- a/lib/importmap/commands.rb
+++ b/lib/importmap/commands.rb
@@ -31,7 +31,7 @@ class Importmap::Commands < Thor
         end
       end
     else
-      puts "Couldn't find any packages in #{packages.inspect} on #{options[:provider]}"
+      puts "Couldn't find any packages in #{packages.inspect} on #{options[:from]}"
     end
   end
 
@@ -53,7 +53,7 @@ class Importmap::Commands < Thor
         end
       end
     else
-      puts "Couldn't find any packages in #{packages.inspect} on #{options[:provider]}"
+      puts "Couldn't find any packages in #{packages.inspect} on #{options[:from]}"
     end
   end
 


### PR DESCRIPTION
`options[:provider]` was renamed to `options[:from]`