### PR TITLE
Make all `pin*` methods behave conventionally the same

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,11 @@ module MyEngine
       app.config.importmap.paths << Engine.root.join("config/importmap.rb")
       # ...
     end
+
+    initializer "my-engine.javascript-assets" do |app|
+      app.config.assets.paths << File.expand_path("../../app/javascript")
+      # ...
+    end
   end
 end
 ```
@@ -220,7 +225,7 @@ And pinning JavaScript modules from the engine:
 ```ruby
 # my_engine/config/importmap.rb
 
-pin_all_from File.expand_path("../app/assets/javascripts", __dir__)
+pin_under "blorgh/application"
 ```
 
 

--- a/test/dummy/config/importmap.rb
+++ b/test/dummy/config/importmap.rb
@@ -1,4 +1,2 @@
-pin_all_from "app/assets/javascripts"
-
 pin "md5", to: "https://cdn.skypack.dev/md5", preload: true
 pin "not_there", to: "nowhere.js"


### PR DESCRIPTION
Please read #66 and #67 to know the background behind why this PR is raised.

This PR replaces `pin_all_from` with `pin_under` which has the same thinking behind it as the `pin` method. Moreover, the `pin_under` method utilizes the `Rails.application.config.assets.paths` to figure out the files needed to be pinned, so that one does not have to specify the folder name from the Rails' root.

There's one thing which is remaining, that is when you specify just the folder name to `pin_all_from`:

```rb
pin_all_from "app/assets/javascripts"
```

it will pin all the files inside the `app/assets/javascripts` folder automatically, which I'm not sure how to do so with `pin_under`; so any and all suggestions are welcome. My idea was to have another method called `pin_all` which will only take one parameter, _e.g._ `"app/assets/javascript"` (from the Rails' root), and will do the job of pinning everything under that folder.

Also, feel free to suggest any changes and I'll be more than happy to do so.