### PR TITLE
Update additional lockfiles after bumping importmap-rails version

### DIFF
--- a/gemfiles/rails_7_propshaft.gemfile.lock
+++ b/gemfiles/rails_7_propshaft.gemfile.lock
@@ -86,7 +86,7 @@ GIT
 PATH
   remote: ..
   specs:
-    importmap-rails (0.8.2)
+    importmap-rails (0.9.0)
       rails (>= 6.0.0)
 
 GEM

--- a/gemfiles/rails_7_sprockets.gemfile.lock
+++ b/gemfiles/rails_7_sprockets.gemfile.lock
@@ -86,7 +86,7 @@ GIT
 PATH
   remote: ..
   specs:
-    importmap-rails (0.8.2)
+    importmap-rails (0.9.0)
       rails (>= 6.0.0)
 
 GEM


### PR DESCRIPTION
Without this, running `bundle install` with `BUNDLE_GEMFILE` set to one of these gemfiles will result in an error like:
```
You are trying to install in deployment mode after changing your
Gemfile. Run `bundle install` elsewhere and add the updated
gemfiles/rails_7_propshaft.gemfile.lock to version control.
```
as seen in the CI run for the commit that bumped the version:
https://github.com/rails/importmap-rails/runs/4297724678?check_suite_focus=true#step:3:30