### PR TITLE
Use consistent style in "importmap.assets" initializer

### DIFF
--- a/lib/importmap/engine.rb
+++ b/lib/importmap/engine.rb
@@ -39,11 +39,11 @@ module Importmap
       end
     end
 
-    initializer "importmap.assets" do
-      if Rails.application.config.respond_to?(:assets)
-        Rails.application.config.assets.precompile += %w( es-module-shims.js es-module-shims.min.js es-module-shims.js.map )
-        Rails.application.config.assets.paths << Rails.root.join("app/javascript")
-        Rails.application.config.assets.paths << Rails.root.join("vendor/javascript")
+    initializer "importmap.assets" do |app|
+      if app.config.respond_to?(:assets)
+        app.config.assets.precompile += %w( es-module-shims.js es-module-shims.min.js es-module-shims.js.map )
+        app.config.assets.paths << Rails.root.join("app/javascript")
+        app.config.assets.paths << Rails.root.join("vendor/javascript")
       end
     end
 


### PR DESCRIPTION
While working on #61, I noticed a minor style inconsistency between the `"importmap.assets"` initializer and the rest of the initializers declared in `lib/importmap/engine.rb`: That one directly references `Rails.application` while the others use the `app` block variable (which makes the code a bit more concise). So this PR is nothing groundbreaking; it just makes them consistent.