### PR TITLE
Fix extra lockfiles again & update release script to handle that automatically

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -4,7 +4,8 @@ VERSION=$1
 
 printf "module Importmap\n  VERSION = \"$VERSION\"\nend\n" > ./lib/importmap/version.rb
 bundle
-git add Gemfile.lock lib/importmap/version.rb
+for gemfile in $(ls gemfiles/*.gemfile); do BUNDLE_GEMFILE="$gemfile" bundle; done
+git add Gemfile.lock gemfiles/*.lock lib/importmap/version.rb
 git commit -m "Bump version for $VERSION"
 git push
 git tag v$VERSION

--- a/gemfiles/rails_7_propshaft.gemfile.lock
+++ b/gemfiles/rails_7_propshaft.gemfile.lock
@@ -86,7 +86,7 @@ GIT
 PATH
   remote: ..
   specs:
-    importmap-rails (0.9.0)
+    importmap-rails (0.9.1)
       rails (>= 6.0.0)
 
 GEM

--- a/gemfiles/rails_7_sprockets.gemfile.lock
+++ b/gemfiles/rails_7_sprockets.gemfile.lock
@@ -86,7 +86,7 @@ GIT
 PATH
   remote: ..
   specs:
-    importmap-rails (0.9.0)
+    importmap-rails (0.9.1)
       rails (>= 6.0.0)
 
 GEM


### PR DESCRIPTION
Related: #75

CI broke again after we bumped the version to 0.9.1:
https://github.com/rails/importmap-rails/runs/4309148366?check_suite_focus=true#step:3:30

This PR updates the additional gemfiles again to reference the new version, which fixes CI (f0f3c1177504e8acc652a8321171e8b3fd05b8e7). Additionally, after discovering the `bin/release` script, I've enhanced it to handle this automatically going forward (77a5b5efa60b6aadd5ea8ca4c674db16dea951af).