### PR TITLE
Update additional lockfiles to fix CI failures in #84

### DIFF
--- a/gemfiles/rails_7_propshaft.gemfile.lock
+++ b/gemfiles/rails_7_propshaft.gemfile.lock
@@ -2,7 +2,8 @@ PATH
   remote: ..
   specs:
     importmap-rails (0.9.4)
-      rails (>= 6.0.0)
+      actionpack (>= 6.0.0)
+      railties (>= 6.0.0)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/rails_7_sprockets.gemfile.lock
+++ b/gemfiles/rails_7_sprockets.gemfile.lock
@@ -2,7 +2,8 @@ PATH
   remote: ..
   specs:
     importmap-rails (0.9.4)
-      rails (>= 6.0.0)
+      actionpack (>= 6.0.0)
+      railties (>= 6.0.0)
 
 GEM
   remote: https://rubygems.org/


### PR DESCRIPTION
This can be done through the appraisal gem via
`bundle exec appraisal install`
or just through bundler via
`for gemfile in $(ls gemfiles/*.gemfile); do BUNDLE_GEMFILE="$gemfile" bundle; done`