### PR TITLE
Allow for custom cache keys for Importmap::Map#preloaded_module_paths and Importmap::Map#to_json

### DIFF
--- a/lib/importmap/map.rb
+++ b/lib/importmap/map.rb
@@ -32,14 +32,23 @@ class Importmap::Map
     @directories[dir] = MappedDir.new(dir: dir, under: under, path: to, preload: preload)
   end
 
-  def preloaded_module_paths(resolver:)
-    cache_as(:preloaded_module_paths) do
+  # Returns an array of all the resolved module paths of the pinned packages. The `resolver` must respond to `asset_path`,
+  # such as `ActionController::Base.helpers` or `ApplicationController.helpers`. You'll want to use the resolver that has
+  # been configured for the `asset_host` you want these resolved paths to use. In case you need to resolve for different
+  # asset hosts, you can pass in a custom `cache_key` to vary the cache used by this method for the different cases.
+  def preloaded_module_paths(resolver:, cache_key: :preloaded_module_paths)
+    cache_as(cache_key) do
       resolve_asset_paths(expanded_preloading_packages_and_directories, resolver: resolver).values
     end
   end
 
-  def to_json(resolver:)
-    cache_as(:json) do
+  # Returns a JSON hash (as a string) of all the resolved module paths of the pinned packages in the import map format.
+  # The `resolver` must respond to `asset_path`, such as `ActionController::Base.helpers` or `ApplicationController.helpers`.
+  # You'll want to use the resolver that has been configured for the `asset_host` you want these resolved paths to use.
+  # In case you need to resolve for different asset hosts, you can pass in a custom `cache_key` to vary the cache used
+  # by this method for the different cases.
+  def to_json(resolver:, cache_key: :json)
+    cache_as(cache_key) do
       JSON.pretty_generate({ "imports" => resolve_asset_paths(expanded_packages_and_directories, resolver: resolver) })
     end
   end


### PR DESCRIPTION
If you're using a custom asset host resolver, you may need to use separate caches for the preloaded module paths and json returns. Otherwise the first resolved asset host will be used to generate these values, which as then cached for all subsequent requests.

We use this in HEY as a consequence of the following asset host resolver:

```ruby
  # Disable the CDN only for the iOS app to allow the app's local proxy to intercept network requests for assets
  config.action_controller.asset_host = Proc.new do |source, request|
    unless request&.user_agent.to_s.match?(/HEY iOS/) && source =~ /\.(css|js)$/
      "https://production.haystack-assets.com"
    end
  end
```

That allows us to call `javascript_inline_importmap_tag` like so:

```ruby
javascript_inline_importmap_tag(Rails.application.importmap.to_json(
  resolver: self, cache_key: "#{platform.ios_app? ? "ios_app" : "all"}_json"
))
```