### PR TITLE
Test invalid importmap file

### DIFF
--- a/lib/importmap/map.rb
+++ b/lib/importmap/map.rb
@@ -13,7 +13,7 @@ class Importmap::Map
     if path && File.exist?(path)
       begin
         instance_eval(File.read(path), path.to_s)
-      rescue Exception => e
+      rescue StandardError => e
         Rails.logger.error "Unable to parse import map from #{path}: #{e.message}"
         raise InvalidFile, "Unable to parse import map from #{path}: #{e.message}"
       end

--- a/lib/importmap/map.rb
+++ b/lib/importmap/map.rb
@@ -3,6 +3,8 @@ require "pathname"
 class Importmap::Map
   attr_reader :packages, :directories
 
+  class InvalidFile < StandardError; end
+
   def initialize
     @packages, @directories = {}, {}
   end
@@ -13,7 +15,7 @@ class Importmap::Map
         instance_eval(File.read(path), path.to_s)
       rescue Exception => e
         Rails.logger.error "Unable to parse import map from #{path}: #{e.message}"
-        raise "Unable to parse import map from #{path}: #{e.message}"
+        raise InvalidFile, "Unable to parse import map from #{path}: #{e.message}"
       end
     elsif block_given?
       instance_eval(&block)

--- a/test/fixtures/files/invalid_import_map.rb
+++ b/test/fixtures/files/invalid_import_map.rb
@@ -1,0 +1,1 @@
+typo "react", to: "https://ga.jspm.io/npm:react@17.0.2/index.js"

--- a/test/importmap_test.rb
+++ b/test/importmap_test.rb
@@ -56,6 +56,14 @@ class ImportmapTest < ActiveSupport::TestCase
     assert_match %r|assets/my_lib-.*\.js|, generate_importmap_json["imports"]["my_lib"]
   end
 
+  test 'invalid importmap file results in error' do
+    file = file_fixture('invalid_import_map.rb')
+    importmap = Importmap::Map.new
+    assert_raises Importmap::Map::InvalidFile do
+      importmap.draw(file)
+    end
+  end
+
   test "preloaded modules are included in preload tags" do
     preloading_module_paths = @importmap.preloaded_module_paths(resolver: ApplicationController.helpers).to_s
     assert_match /md5/, preloading_module_paths


### PR DESCRIPTION
This PR adds a test to cover an invalid importmap file and makes use of a custom error class for easier error tracking.

While I was in there I noticed we're rescuing `Exception`s rather than `StandardError`s when parsing importmap files. That's interesting to me as it's usually something I avoid doing—Exceptions are raised by events like a system interrupt, which I imagine we wouldn't want to swallow. I'm happy to remove that commit if it's required though 😄 

