### PR TITLE
Fix net http request on ruby 2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,12 @@ In Firefox. when opening the browser console, the asm.js module lexer build will
 
 Under certain circumstances, like running system tests using chromedriver under CI (which may be resource constrained and trigger errors in certain cases), you may want to explicitly turn off including the shim. You can do this by calling the bulk tag helper with `javascript_importmap_tags("application", shim: false)`. Thus you can pass in something like `shim: !ENV["CI"]`. If you want, and are sure you're not doing any full-page caching, you can also connect this directive to a user agent check (using a gem like `useragent`) to check whether the browser is chrome/edge 89+. But you really shouldn't have to, as the shim is designed to gracefully work with natively compatible drivers.
 
+## Checking for outdated or vulnerable packages
+
+Importmap for Rails provides two commands to check your pinned packages:
+- `./bin/importmap outdated` checks the NPM registry for new versions
+- `./bin/importmap audit` checks the NPM registry for known security issues
+
 ## License
 
 Importmap for Rails is released under the [MIT License](https://opensource.org/licenses/MIT).

--- a/lib/importmap/npm.rb
+++ b/lib/importmap/npm.rb
@@ -71,7 +71,14 @@ class Importmap::Npm
     end
 
     def get_json(uri)
-      Net::HTTP.get(uri, "Content-Type" => "application/json")
+      request = Net::HTTP::Get.new(uri)
+      request["Content-Type"] = "application/json"
+
+      response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |http|
+        http.request(request)
+      }
+
+      response.body
     rescue => error
       raise HTTPError, "Unexpected transport error (#{error.class}: #{error.message})"
     end

--- a/test/npm_test.rb
+++ b/test/npm_test.rb
@@ -32,7 +32,7 @@ class Importmap::NpmTest < ActiveSupport::TestCase
   end
 
   test "failed outdated packages request with mock" do
-    Net::HTTP.stub(:get, proc { raise "Unexpected Error" }) do
+    Net::HTTP.stub(:start, proc { raise "Unexpected Error" }) do
       assert_raises(Importmap::Npm::HTTPError) do
         @npm.outdated_packages
       end


### PR DESCRIPTION
I've just noticed that #109 isn't working under 2.7 (my bad on not trying that version locally and thinking that it'd run on CI before getting merged :grimacing: :man_facepalming:).

The reason is that Ruby 3.0 added the ability to set headers on the `Net::HTTP.get` call, while 2.7 doesn't have that, and so it breaks.

This fixes that by changing the Get request.

I've tried and the `Content-Type` header is not required by the NPM server (so a simple `Net::HTTP.get(uri)` would work), but I prefer sending it just to be future-proof in case they'll require it.

I've also added a couple of lines to the Readme to mention the two new commands.

It might be worth releasing a v1.1.1 with this fix. Sorry for the trouble :sweat_smile: 

/cc @dhh 