### PR TITLE
Fix using javascript_importmap_tag in console

### DIFF
--- a/app/helpers/importmap/importmap_tags_helper.rb
+++ b/app/helpers/importmap/importmap_tags_helper.rb
@@ -14,12 +14,12 @@ module Importmap::ImportmapTagsHelper
   # By default, `Rails.application.importmap.to_json(resolver: self)` is used.
   def javascript_inline_importmap_tag(importmap_json = Rails.application.importmap.to_json(resolver: self))
     tag.script importmap_json.html_safe,
-      type: "importmap", "data-turbo-track": "reload", nonce: content_security_policy_nonce
+      type: "importmap", "data-turbo-track": "reload", nonce: request&.content_security_policy
   end
 
   # Configure es-modules-shim with nonce support if the application is using a content security policy.
   def javascript_importmap_shim_nonce_configuration_tag
-    if content_security_policy?
+    if request&.content_security_policy
       tag.script({ nonce: content_security_policy_nonce }.to_json.html_safe, 
         type: "esms-options", nonce: content_security_policy_nonce)
     end
@@ -28,14 +28,14 @@ module Importmap::ImportmapTagsHelper
   # Include the es-modules-shim needed to make importmaps work in browsers without native support (like Firefox + Safari).
   def javascript_importmap_shim_tag(minimized: true)
     javascript_include_tag minimized ? "es-module-shims.min.js" : "es-module-shims.js",
-      async: true, "data-turbo-track": "reload", nonce: content_security_policy_nonce
+      async: true, "data-turbo-track": "reload", nonce: request&.content_security_policy
   end
 
   # Import a named JavaScript module(s) using a script-module tag.
   def javascript_import_module_tag(*module_names)
     imports = Array(module_names).collect { |m| %(import "#{m}") }.join("\n")
     tag.script imports.html_safe, 
-      type: "module", nonce: content_security_policy_nonce
+      type: "module", nonce: request&.content_security_policy
   end
 
   # Link tags for preloading all modules marked as preload: true in the `importmap`
@@ -48,7 +48,7 @@ module Importmap::ImportmapTagsHelper
   # Link tag(s) for preloading the JavaScript module residing in `*paths`. Will return one link tag per path element.
   def javascript_module_preload_tag(*paths)
     safe_join(Array(paths).collect { |path|
-      tag.link rel: "modulepreload", href: path, nonce: content_security_policy_nonce
+      tag.link rel: "modulepreload", href: path, nonce: request&.content_security_policy
     }, "\n")
   end
 end

--- a/test/importmap_tags_helper_test.rb
+++ b/test/importmap_tags_helper_test.rb
@@ -1,9 +1,5 @@
 require "test_helper"
 
-# Stub method
-def content_security_policy_nonce() nil end
-def content_security_policy?() false end
-
 class Importmap::ImportmapTagsHelperTest < ActionView::TestCase
   test "javascript_importmap_tags with and without shim" do
     assert_match /shim/, javascript_importmap_tags("application")


### PR DESCRIPTION
### Summary

Previously this would error because there is no request object in the
console for `content_security_policy_nonce` to be called on.

### Other information

~This is based on #138 which should be merged first~ ✔️ 

Fixes rails/rails#44809