### PR TITLE
Fix reloader test flakiness

### DIFF
--- a/test/reloader_test.rb
+++ b/test/reloader_test.rb
@@ -24,7 +24,7 @@ class ReloaderTest < ActiveSupport::TestCase
 
   private
     def touch_config
-      FileUtils.touch(@config)
       sleep 1
+      FileUtils.touch(@config)
     end
 end


### PR DESCRIPTION
This `sleep 1` was added in 2df91f6 to address CI failures, however this
has not appeared to fix the issues.

When investigating how the FileUpdateChecker tests worked in Rails, I
realized that the sleep is actually on the other side of the touch. Its
purpose is to ensure that there is separation between the create and
update times of the files (so that the reloader can identify the
change), so it should go before the touch.