### PR TITLE
Add more tests for helpers

### DIFF
--- a/app/helpers/importmap/importmap_tags_helper.rb
+++ b/app/helpers/importmap/importmap_tags_helper.rb
@@ -20,8 +20,8 @@ module Importmap::ImportmapTagsHelper
   # Configure es-modules-shim with nonce support if the application is using a content security policy.
   def javascript_importmap_shim_nonce_configuration_tag
     if request&.content_security_policy
-      tag.script({ nonce: content_security_policy_nonce }.to_json.html_safe, 
-        type: "esms-options", nonce: content_security_policy_nonce)
+      tag.script({ nonce: request.content_security_policy_nonce }.to_json.html_safe,
+        type: "esms-options", nonce: request.content_security_policy_nonce)
     end
   end
 

--- a/test/importmap_tags_helper_test.rb
+++ b/test/importmap_tags_helper_test.rb
@@ -1,6 +1,24 @@
 require "test_helper"
 
 class Importmap::ImportmapTagsHelperTest < ActionView::TestCase
+  attr_reader :request
+
+  class FakeRequest
+    def initialize(nonce = nil)
+      @nonce = nonce
+    end
+
+    def send_early_hints(links); end
+
+    def content_security_policy
+      Object.new if @nonce
+    end
+
+    def content_security_policy_nonce
+      @nonce
+    end
+  end
+
   test "javascript_importmap_tags with and without shim" do
     assert_match /shim/, javascript_importmap_tags("application")
     assert_no_match /shim/, javascript_importmap_tags("application", shim: false)
@@ -16,5 +34,25 @@ class Importmap::ImportmapTagsHelperTest < ActionView::TestCase
     assert_dom_equal \
       %(<link rel="modulepreload" href="https://cdn.skypack.dev/md5">),
       javascript_importmap_module_preload_tags
+  end
+
+  test "tags have no nonce if CSP is not configured" do
+    @request = FakeRequest.new
+
+    assert_no_match /nonce/, javascript_importmap_tags("application")
+  ensure
+    @request = nil
+  end
+
+  test "tags have nonce if CSP is configured" do
+    @request = FakeRequest.new("iyhD0Yc0W+c=")
+
+    assert_match /nonce="iyhD0Yc0W\+c="/, javascript_inline_importmap_tag
+    assert_match /nonce="iyhD0Yc0W\+c="/, javascript_importmap_shim_nonce_configuration_tag
+    assert_match /nonce="iyhD0Yc0W\+c="/, javascript_importmap_shim_tag
+    assert_match /nonce="iyhD0Yc0W\+c="/, javascript_import_module_tag("application")
+    assert_match /nonce="iyhD0Yc0W\+c="/, javascript_importmap_module_preload_tags
+  ensure
+    @request = nil
   end
 end


### PR DESCRIPTION
Regression tests for 357d7ba

The FakeRequest object is modeled after the one used for similar tests
for the Rails asset tags

https://github.com/rails/rails/blob/9994d38bc6c1a8662e510d26c0e9ca8c24ab1189/actionview/test/template/asset_tag_helper_test.rb#L27

cc @rmacklin Thanks for fixing this, sorry about that