### PR TITLE
Allow single quotes in config/importmaps.rb

### DIFF
--- a/lib/importmap/packager.rb
+++ b/lib/importmap/packager.rb
@@ -48,7 +48,7 @@ class Importmap::Packager
   end
 
   def packaged?(package)
-    importmap.match(/^pin "#{package}".*$/)
+    importmap.match(/^pin ["']#{package}["'].*$/)
   end
 
   def download(package, url)
@@ -102,7 +102,7 @@ class Importmap::Packager
 
     def remove_package_from_importmap(package)
       all_lines = File.readlines(@importmap_path)
-      with_lines_removed = all_lines.select { |line| line !~ /pin "#{package}"/ }
+      with_lines_removed = all_lines.grep_v(/pin ["']#{package}["']/)
 
       File.open(@importmap_path, "w") do |file|
         with_lines_removed.each { |line| file.write(line) }

--- a/test/packager_single_quotes_test.rb
+++ b/test/packager_single_quotes_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+require "importmap/packager"
+
+class Importmap::PackagerSingleQuotesTest < ActiveSupport::TestCase
+  setup do
+    @single_quote_config_name = Rails.root.join("config/importmap_with_single_quotes.rb")
+    File.write(@single_quote_config_name, File.read(Rails.root.join("config/importmap.rb")).tr('"', "'"))
+    @packager = Importmap::Packager.new(@single_quote_config_name)
+  end
+
+  teardown { File.delete(@single_quote_config_name) }
+
+  test "packaged? with single quotes" do
+    assert @packager.packaged?("md5")
+    assert_not @packager.packaged?("md5-extension")
+  end
+
+  test "remove package with single quotes" do
+    assert @packager.remove("md5")
+    assert_not @packager.packaged?("md5")
+  end
+end


### PR DESCRIPTION
The default settings in Rubocop will change the double quotes in `config/importmap.rb` to single quotes.  This breaks the `bin/importmap pin` and `bin/importmap unpin` commands.

This simple patch will enable both commands to work with single quotes.