### PR TITLE
Enable shim mode in Firefox and Safari

### DIFF
--- a/test/importmap_tags_helper_test.rb
+++ b/test/importmap_tags_helper_test.rb
@@ -24,10 +24,13 @@ class Importmap::ImportmapTagsHelperTest < ActionView::TestCase
     assert_no_match /shim/, javascript_importmap_tags("application", shim: false)
   end
 
-  test "javascript_inline_importmap_tag" do
+  test "javascript_inline_importmap_tag with and without shim" do
+    assert_match \
+      %r{<script type="importmap-shim" data-turbo-track="reload">{\n  \"imports\": {\n    \"md5\": \"https://cdn.skypack.dev/md5\",\n    \"not_there\": \"/nowhere.js\"\n  }\n}</script>},
+      javascript_inline_importmap_tag
     assert_match \
       %r{<script type="importmap" data-turbo-track="reload">{\n  \"imports\": {\n    \"md5\": \"https://cdn.skypack.dev/md5\",\n    \"not_there\": \"/nowhere.js\"\n  }\n}</script>},
-      javascript_inline_importmap_tag
+      javascript_inline_importmap_tag(shim: false)
   end
 
   test "javascript_importmap_module_preload_tags" do


### PR DESCRIPTION
#131
Even if you use es-module-shims, shim mode isn't enabled, so importmap-rails gem doesn't work properly in Firefox and Safari.
https://github.com/guybedford/es-module-shims#shim-mode

Judge the shim parameter and switch the script tag type attributes.