### PR TITLE
Adds Ruby 3.2 to the CI matrix. Also updates checkout action version.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 jobs:
   tests:
     strategy:
+      fail-fast: false
       matrix:
         ruby-version:
           - "2.7"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ jobs:
           - "2.7"
           - "3.0"
           - "3.1"
+          - "3.2"
         gemfile:
           - Gemfile
           - gemfiles/rails_7_propshaft.gemfile
@@ -22,7 +23,7 @@ jobs:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - name: Install Ruby
         uses: ruby/setup-ruby@v1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,14 +103,14 @@ GEM
     mini_mime (1.1.2)
     minitest (5.16.2)
     nio4r (2.5.8)
-    nokogiri (1.13.6-arm64-darwin)
+    nokogiri (1.14.0-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.6-x86_64-darwin)
+    nokogiri (1.14.0-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.6-x86_64-linux)
+    nokogiri (1.14.0-x86_64-linux)
       racc (~> 1.4)
     public_suffix (4.0.7)
-    racc (1.6.0)
+    racc (1.6.2)
     rack (2.2.4)
     rack-test (2.0.2)
       rack (>= 1.3)
@@ -183,6 +183,7 @@ PLATFORMS
   arm64-darwin-21
   x86_64-darwin-20
   x86_64-darwin-21
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES
@@ -199,4 +200,4 @@ DEPENDENCIES
   webdrivers
 
 BUNDLED WITH
-   2.3.17
+   2.4.3

--- a/gemfiles/rails_7_propshaft.gemfile.lock
+++ b/gemfiles/rails_7_propshaft.gemfile.lock
@@ -124,11 +124,11 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
-    nokogiri (1.13.6-arm64-darwin)
+    nokogiri (1.14.0-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.6-x86_64-darwin)
+    nokogiri (1.14.0-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.6-x86_64-linux)
+    nokogiri (1.14.0-x86_64-linux)
       racc (~> 1.4)
     propshaft (0.6.4)
       actionpack (>= 7.0.0)
@@ -136,7 +136,7 @@ GEM
       rack
       railties (>= 7.0.0)
     public_suffix (4.0.7)
-    racc (1.6.0)
+    racc (1.6.2)
     rack (2.2.4)
     rack-test (2.0.2)
       rack (>= 1.3)
@@ -202,6 +202,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   x86_64-darwin-21
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES
@@ -219,4 +220,4 @@ DEPENDENCIES
   webdrivers
 
 BUNDLED WITH
-   2.3.17
+   2.4.3

--- a/gemfiles/rails_7_sprockets.gemfile.lock
+++ b/gemfiles/rails_7_sprockets.gemfile.lock
@@ -124,14 +124,14 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
-    nokogiri (1.13.6-arm64-darwin)
+    nokogiri (1.14.0-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.6-x86_64-darwin)
+    nokogiri (1.14.0-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.6-x86_64-linux)
+    nokogiri (1.14.0-x86_64-linux)
       racc (~> 1.4)
     public_suffix (4.0.7)
-    racc (1.6.0)
+    racc (1.6.2)
     rack (2.2.4)
     rack-test (2.0.2)
       rack (>= 1.3)
@@ -204,6 +204,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   x86_64-darwin-21
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES
@@ -221,4 +222,4 @@ DEPENDENCIES
   webdrivers
 
 BUNDLED WITH
-   2.3.17
+   2.4.3


### PR DESCRIPTION
To get this to run green I had to upgrade Nokogiri in the lockfile.

Also added `fail-fast: false` to the CI configuration to make analyzing issues easier.

Runs green on my fork.