### PR TITLE
Respect `config.enable_reloading`

### DIFF
--- a/lib/importmap/engine.rb
+++ b/lib/importmap/engine.rb
@@ -20,15 +20,17 @@ module Importmap
     end
 
     initializer "importmap.reloader" do |app|
-      Importmap::Reloader.new.tap do |reloader|
-        reloader.execute
-        app.reloaders << reloader
-        app.reloader.to_run { reloader.execute }
+      unless app.config.cache_classes
+        Importmap::Reloader.new.tap do |reloader|
+          reloader.execute
+          app.reloaders << reloader
+          app.reloader.to_run { reloader.execute }
+        end
       end
     end
 
     initializer "importmap.cache_sweeper" do |app|
-      if app.config.importmap.sweep_cache
+      if app.config.importmap.sweep_cache && !app.config.cache_classes
         app.config.importmap.cache_sweepers << app.root.join("app/javascript")
         app.config.importmap.cache_sweepers << app.root.join("vendor/javascript")
         app.importmap.cache_sweeper(watches: app.config.importmap.cache_sweepers)

--- a/lib/importmap/map.rb
+++ b/lib/importmap/map.rb
@@ -69,7 +69,7 @@ class Importmap::Map
     Digest::SHA1.hexdigest(to_json(resolver: resolver).to_s)
   end
 
-  # Returns an instance ActiveSupport::EventedFileUpdateChecker configured to clear the cache of the map
+  # Returns an instance of ActiveSupport::EventedFileUpdateChecker configured to clear the cache of the map
   # when the directories passed on initialization via `watches:` have changes. This is used in development
   # and test to ensure the map caches are reset when javascript files are changed.
   def cache_sweeper(watches: nil)


### PR DESCRIPTION
Currently importmap-rails adds some file watchers even when `enable_reloading` is false. This PR fixes that. This way, the reloader will not run in a test environment where reloading is off by default.