### PR TITLE
Accept Cache Key for Inline & Preloaded Module in Importmap Tag

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,6 +181,7 @@ GEM
 PLATFORMS
   arm64-darwin-20
   arm64-darwin-21
+  arm64-darwin-22
   x86_64-darwin-20
   x86_64-darwin-21
   x86_64-darwin-22

--- a/app/helpers/importmap/importmap_tags_helper.rb
+++ b/app/helpers/importmap/importmap_tags_helper.rb
@@ -1,9 +1,9 @@
 module Importmap::ImportmapTagsHelper
   # Setup all script tags needed to use an importmap-powered entrypoint (which defaults to application.js)
-  def javascript_importmap_tags(entry_point = "application", shim: true)
+  def javascript_importmap_tags(entry_point = "application", shim: true, inline_importmap_cache_key: :json, module_preload_tags_cache_key: :preloaded_module_paths)
     safe_join [
-      javascript_inline_importmap_tag,
-      javascript_importmap_module_preload_tags,
+      javascript_inline_importmap_tag(Rails.application.importmap.to_json(resolver: self, cache_key: inline_importmap_cache_key)),
+      javascript_importmap_module_preload_tags(cache_key: module_preload_tags_cache_key),
       (javascript_importmap_shim_nonce_configuration_tag if shim),
       (javascript_importmap_shim_tag if shim),
       javascript_import_module_tag(entry_point)
@@ -34,15 +34,15 @@ module Importmap::ImportmapTagsHelper
   # Import a named JavaScript module(s) using a script-module tag.
   def javascript_import_module_tag(*module_names)
     imports = Array(module_names).collect { |m| %(import "#{m}") }.join("\n")
-    tag.script imports.html_safe, 
+    tag.script imports.html_safe,
       type: "module", nonce: request&.content_security_policy_nonce
   end
 
   # Link tags for preloading all modules marked as preload: true in the `importmap`
   # (defaults to Rails.application.importmap), such that they'll be fetched
   # in advance by browsers supporting this link type (https://caniuse.com/?search=modulepreload).
-  def javascript_importmap_module_preload_tags(importmap = Rails.application.importmap)
-    javascript_module_preload_tag(*importmap.preloaded_module_paths(resolver: self))
+  def javascript_importmap_module_preload_tags(importmap = Rails.application.importmap, cache_key: :preloaded_module_paths)
+    javascript_module_preload_tag(*importmap.preloaded_module_paths(resolver: self, cache_key: cache_key))
   end
 
   # Link tag(s) for preloading the JavaScript module residing in `*paths`. Will return one link tag per path element.

--- a/test/importmap_tags_helper_test.rb
+++ b/test/importmap_tags_helper_test.rb
@@ -55,4 +55,28 @@ class Importmap::ImportmapTagsHelperTest < ActionView::TestCase
   ensure
     @request = nil
   end
+
+  test "separate caches for inline importmap" do
+    set_one = javascript_importmap_tags(inline_importmap_cache_key: 'inline-1')
+    ActionController::Base.asset_host = "http://assets.example.com"
+
+    set_two = javascript_importmap_tags(inline_importmap_cache_key: 'inline-2')
+
+    assert_not_equal set_one, set_two
+    assert_match /assets\.example\.com/, javascript_importmap_tags(set_one)
+  ensure
+    ActionController::Base.asset_host = nil
+  end
+
+  test "separate caches for preloaded modules" do
+    set_one = javascript_importmap_tags(module_preload_tags_cache_key: 'preload-1')
+    ActionController::Base.asset_host = "http://assets.example.com"
+
+    set_two = javascript_importmap_tags(module_preload_tags_cache_key: 'preload-2')
+
+    assert_not_equal set_one, set_two
+    assert_match /assets\.example\.com/, javascript_importmap_tags(set_one)
+  ensure
+    ActionController::Base.asset_host = nil
+  end
 end

--- a/test/importmap_tags_helper_test.rb
+++ b/test/importmap_tags_helper_test.rb
@@ -63,7 +63,7 @@ class Importmap::ImportmapTagsHelperTest < ActionView::TestCase
     set_two = javascript_importmap_tags(inline_importmap_cache_key: 'inline-2')
 
     assert_not_equal set_one, set_two
-    assert_match /assets\.example\.com/, javascript_importmap_tags(set_one)
+    assert_match /assets\.example\.com/, set_two
   ensure
     ActionController::Base.asset_host = nil
   end
@@ -75,7 +75,7 @@ class Importmap::ImportmapTagsHelperTest < ActionView::TestCase
     set_two = javascript_importmap_tags(module_preload_tags_cache_key: 'preload-2')
 
     assert_not_equal set_one, set_two
-    assert_match /assets\.example\.com/, javascript_importmap_tags(set_one)
+    assert_match /assets\.example\.com/, set_two
   ensure
     ActionController::Base.asset_host = nil
   end


### PR DESCRIPTION
Hello,

We have multi-tenant application and needed to generate different importmap tags for each tenant. I can see in #88 that some helpers already support passing custom cache keys, however, `javascript_importmap_tags` does not support that. 

I couldn't make application working by rendering only `javascript_inline_importmap_tag` and `javascript_importmap_module_preload_tags` in `<head />`. I'm not sure about other `shim` ones and `javascript_import_module_tag` helpers - they needed to be in there.

So that PR allows you to pass in custom cache keys to `javascript_importmap_tags`.

- inline JS modules
- preloaded JS modules

into `javascript_importmap_tags`. 



