### PR TITLE
Add a packages command to get package info

### DIFF
--- a/lib/importmap/commands.rb
+++ b/lib/importmap/commands.rb
@@ -8,7 +8,7 @@ class Importmap::Commands < Thor
   def self.exit_on_failure?
     false
   end
-  
+
   desc "pin [*PACKAGES]", "Pin new packages"
   option :env, type: :string, aliases: :e, default: "production"
   option :from, type: :string, aliases: :f, default: "jspm"
@@ -101,6 +101,11 @@ class Importmap::Commands < Thor
     else
       puts "No outdated packages found"
     end
+  end
+
+  desc "packages", "Print out packages with version numbers"
+  def packages
+    puts npm.packages_with_versions.map { |x| x.join(' ') }
   end
 
   private

--- a/lib/importmap/npm.rb
+++ b/lib/importmap/npm.rb
@@ -44,17 +44,19 @@ class Importmap::Npm
     end.sort_by { |p| [p.name, p.severity] }
   end
 
+  def packages_with_versions
+    # We cannot use the name after "pin" because some dependencies are loaded from inside packages
+    # Eg. pin "buffer", to: "https://ga.jspm.io/npm:@jspm/core@2.0.0-beta.19/nodelibs/browser/buffer.js"
+
+    importmap.scan(/^pin .*(?<=npm:|npm\/|skypack\.dev\/|unpkg\.com\/)(.*)(?=@\d+\.\d+\.\d+)@(\d+\.\d+\.\d+(?:[^\/\s"]*)).*$/) |
+      importmap.scan(/^pin "([^"]*)".* #.*@(\d+\.\d+\.\d+(?:[^\s]*)).*$/)
+  end
+
   private
     OutdatedPackage   = Struct.new(:name, :current_version, :latest_version, :error, keyword_init: true)
     VulnerablePackage = Struct.new(:name, :severity, :vulnerable_versions, :vulnerability, keyword_init: true)
 
-    def packages_with_versions
-      # We cannot use the name after "pin" because some dependencies are loaded from inside packages
-      # Eg. pin "buffer", to: "https://ga.jspm.io/npm:@jspm/core@2.0.0-beta.19/nodelibs/browser/buffer.js"
 
-      importmap.scan(/^pin .*(?<=npm:|npm\/|skypack\.dev\/|unpkg\.com\/)(.*)(?=@\d+\.\d+\.\d+)@(\d+\.\d+\.\d+(?:[^\/\s"]*)).*$/) |
-        importmap.scan(/^pin "([^"]*)".* #.*@(\d+\.\d+\.\d+(?:[^\s]*)).*$/)
-    end
 
     def importmap
       @importmap ||= File.read(@importmap_path)


### PR DESCRIPTION
While setting up my app, I've found a few times where I want to know what packages I have in my importmap, as well as their pinned version. I could use a regex to get that myself, but this feels like something that should really be built into importmap-rails.