### PR TITLE
Fix error where pins can be added to the same line as existing pins.

### DIFF
--- a/lib/importmap/commands.rb
+++ b/lib/importmap/commands.rb
@@ -28,7 +28,7 @@ class Importmap::Commands < Thor
         if packager.packaged?(package)
           gsub_file("config/importmap.rb", /^pin "#{package}".*$/, pin, verbose: false)
         else
-          append_to_file("config/importmap.rb", "#{pin}\n", verbose: false)
+          append_to_file("config/importmap.rb", "\n#{pin}\n", verbose: false)
         end
       end
     else


### PR DESCRIPTION
Replicate error:
Start new rails app.
add some code to importmap.rb, save it without a newline at the end call bin/importmap to pin something
The new pin will be put on the same line as your last line, instead of on a new line. Can cause compilation errors.

The newline makes more sense at the beginning here anyway, as we are always appending to the end of the file. But I don't suggest removing the second newline character in case existing implementations elsewhere depend on it.