### PR TITLE
Add support for passing a custom importmap to the tag helper

### DIFF
--- a/app/helpers/importmap/importmap_tags_helper.rb
+++ b/app/helpers/importmap/importmap_tags_helper.rb
@@ -1,9 +1,9 @@
 module Importmap::ImportmapTagsHelper
   # Setup all script tags needed to use an importmap-powered entrypoint (which defaults to application.js)
-  def javascript_importmap_tags(entry_point = "application", shim: true)
+  def javascript_importmap_tags(entry_point = "application", shim: true, importmap: Rails.application.importmap)
     safe_join [
-      javascript_inline_importmap_tag,
-      javascript_importmap_module_preload_tags,
+      javascript_inline_importmap_tag(importmap.to_json(resolver: self)),
+      javascript_importmap_module_preload_tags(importmap),
       (javascript_importmap_shim_nonce_configuration_tag if shim),
       (javascript_importmap_shim_tag if shim),
       javascript_import_module_tag(entry_point)
@@ -34,7 +34,7 @@ module Importmap::ImportmapTagsHelper
   # Import a named JavaScript module(s) using a script-module tag.
   def javascript_import_module_tag(*module_names)
     imports = Array(module_names).collect { |m| %(import "#{m}") }.join("\n")
-    tag.script imports.html_safe, 
+    tag.script imports.html_safe,
       type: "module", nonce: request&.content_security_policy_nonce
   end
 

--- a/lib/importmap/packager.rb
+++ b/lib/importmap/packager.rb
@@ -110,8 +110,6 @@ class Importmap::Packager
     end
 
     def download_package_file(package, url)
-      return `curl -s '#{url}' > #{vendored_package_path(package)}` if url =~ /jspm.io/
-
       response = Net::HTTP.get_response(URI(url))
 
       if response.code == "200"

--- a/lib/importmap/packager.rb
+++ b/lib/importmap/packager.rb
@@ -110,6 +110,8 @@ class Importmap::Packager
     end
 
     def download_package_file(package, url)
+      return `curl -s '#{url}' > #{vendored_package_path(package)}` if url =~ /jspm.io/
+
       response = Net::HTTP.get_response(URI(url))
 
       if response.code == "200"

--- a/test/importmap_tags_helper_test.rb
+++ b/test/importmap_tags_helper_test.rb
@@ -55,4 +55,18 @@ class Importmap::ImportmapTagsHelperTest < ActionView::TestCase
   ensure
     @request = nil
   end
+
+  test "using a custom importmap" do
+    importmap = Importmap::Map.new
+    importmap.pin "foo", preload: true
+    importmap.pin "bar", preload: false
+    importmap_html = javascript_importmap_tags("foo", importmap: importmap)
+
+    assert_includes importmap_html, %{<script type="importmap" data-turbo-track="reload">}
+    assert_includes importmap_html, %{"foo": "/foo.js"}
+    assert_includes importmap_html, %{"bar": "/bar.js"}
+    assert_includes importmap_html, %{<link rel="modulepreload" href="/foo.js">}
+    refute_includes importmap_html, %{<link rel="modulepreload" href="/bar.js">}
+    assert_includes importmap_html, %{<script type="module">import "foo"</script>}
+  end
 end


### PR DESCRIPTION
This is a great feature whenever you have separate areas of the application with completely different sets of dependencies.

The most common example of that is admin areas, both on the main Rails application or coming from engines.

SpinaCMS for example had to add a custom helper https://github.com/SpinaCMS/Spina/blob/400821ddd27aad76c0ff29ac603fb934b5d7e648/app/helpers/spina/spina_helper.rb