### PR TITLE
Add single quote support in `importmap.rb`

### DIFF
--- a/lib/importmap/npm.rb
+++ b/lib/importmap/npm.rb
@@ -48,8 +48,8 @@ class Importmap::Npm
     # We cannot use the name after "pin" because some dependencies are loaded from inside packages
     # Eg. pin "buffer", to: "https://ga.jspm.io/npm:@jspm/core@2.0.0-beta.19/nodelibs/browser/buffer.js"
 
-    importmap.scan(/^pin .*(?<=npm:|npm\/|skypack\.dev\/|unpkg\.com\/)(.*)(?=@\d+\.\d+\.\d+)@(\d+\.\d+\.\d+(?:[^\/\s"]*)).*$/) |
-      importmap.scan(/^pin "([^"]*)".* #.*@(\d+\.\d+\.\d+(?:[^\s]*)).*$/)
+    importmap.scan(/^pin .*(?<=npm:|npm\/|skypack\.dev\/|unpkg\.com\/)(.*)(?=@\d+\.\d+\.\d+)@(\d+\.\d+\.\d+(?:[^\/\s["|']]*)).*$/) |
+      importmap.scan(/^pin ["|']([^["|']]*)["|'].* #.*@(\d+\.\d+\.\d+(?:[^\s]*)).*$/)
   end
 
   private

--- a/lib/importmap/npm.rb
+++ b/lib/importmap/npm.rb
@@ -48,8 +48,8 @@ class Importmap::Npm
     # We cannot use the name after "pin" because some dependencies are loaded from inside packages
     # Eg. pin "buffer", to: "https://ga.jspm.io/npm:@jspm/core@2.0.0-beta.19/nodelibs/browser/buffer.js"
 
-    importmap.scan(/^pin .*(?<=npm:|npm\/|skypack\.dev\/|unpkg\.com\/)(.*)(?=@\d+\.\d+\.\d+)@(\d+\.\d+\.\d+(?:[^\/\s["|']]*)).*$/) |
-      importmap.scan(/^pin ["|']([^["|']]*)["|'].* #.*@(\d+\.\d+\.\d+(?:[^\s]*)).*$/)
+    importmap.scan(/^pin .*(?<=npm:|npm\/|skypack\.dev\/|unpkg\.com\/)(.*)(?=@\d+\.\d+\.\d+)@(\d+\.\d+\.\d+(?:[^\/\s["']]*)).*$/) |
+      importmap.scan(/^pin ["']([^["']]*)["'].* #.*@(\d+\.\d+\.\d+(?:[^\s]*)).*$/)
   end
 
   private

--- a/test/fixtures/files/single_quote_outdated_import_map.rb
+++ b/test/fixtures/files/single_quote_outdated_import_map.rb
@@ -1,0 +1,1 @@
+pin 'md5', to: 'https://cdn.skypack.dev/md5@2.2.0', preload: true

--- a/test/fixtures/files/single_quote_outdated_import_map_without_cdn.rb
+++ b/test/fixtures/files/single_quote_outdated_import_map_without_cdn.rb
@@ -1,0 +1,1 @@
+pin 'md5', preload: true #@2.2.0

--- a/test/npm_test.rb
+++ b/test/npm_test.rb
@@ -18,6 +18,34 @@ class Importmap::NpmTest < ActiveSupport::TestCase
     end
   end
 
+  test "successful outdated packages using single-quotes with mock" do
+    npm = Importmap::Npm.new(file_fixture("single_quote_outdated_import_map.rb"))
+    response = { "dist-tags" => { "latest" => '2.3.0' } }.to_json
+
+    npm.stub(:get_json, response) do
+      outdated_packages = npm.outdated_packages
+
+      assert_equal(1, outdated_packages.size)
+      assert_equal('md5', outdated_packages[0].name)
+      assert_equal('2.2.0', outdated_packages[0].current_version)
+      assert_equal('2.3.0', outdated_packages[0].latest_version)
+    end
+  end
+
+  test "successful outdated packages using single-quotes and without CDN with mock" do
+    npm = Importmap::Npm.new(file_fixture("single_quote_outdated_import_map_without_cdn.rb"))
+    response = { "dist-tags" => { "latest" => '2.3.0' } }.to_json
+
+    npm.stub(:get_json, response) do
+      outdated_packages = npm.outdated_packages
+
+      assert_equal(1, outdated_packages.size)
+      assert_equal('md5', outdated_packages[0].name)
+      assert_equal('2.2.0', outdated_packages[0].current_version)
+      assert_equal('2.3.0', outdated_packages[0].latest_version)
+    end
+  end
+
   test "missing outdated packages with mock" do
     response = { "error" => "Not found" }.to_json
 


### PR DESCRIPTION
Related issue: https://github.com/rails/importmap-rails/issues/156

# Problem

Wrapping strings with single-quotes in the `importmap.rb` file is not picked up by commands `audit` and `outdated`.

# Expectation

The `audit` and `outdated` commands should pick up pins where either double or single quotes are used.

# Solution

The problematic lines are the following:

* https://github.com/rails/importmap-rails/blob/9eec49a9ea3feaab224871437cf1bc2479801796/lib/importmap/npm.rb#L51
* https://github.com/rails/importmap-rails/blob/9eec49a9ea3feaab224871437cf1bc2479801796/lib/importmap/npm.rb#L52

The regex are designed to only scan for double-quotes. The proposed change adds in detection for double-quotes and single-quotes.

The implementation proposed is a bit naive in that strings wrapped with one double-quote and one single-quote will return positive. For example, `pin "local_time' #@2.1.0` will return positive. Running `outdated` and `audit` will run without issue. On a Rails app using importmap, the `SyntaxError: unterminated string meets end of file` will raise.

Whether or not it is important to address this quirk is up for discussion.

Below are how example pins (taken from issue #156 and test fixtures) fair against the updated regexes.

* Updated line 51 regex: https://rubular.com/r/qdhkDJFeRqIXAq
* Updated line 52 regex: https://rubular.com/r/gXRQ10wCo9twC2