### PR TITLE
Add SRI support

### DIFF
--- a/app/helpers/importmap/importmap_tags_helper.rb
+++ b/app/helpers/importmap/importmap_tags_helper.rb
@@ -4,7 +4,8 @@ module Importmap::ImportmapTagsHelper
     safe_join [
       javascript_inline_importmap_tag(importmap.to_json(resolver: self)),
       javascript_importmap_module_preload_tags(importmap),
-      (javascript_importmap_shim_nonce_configuration_tag if shim),
+      (javascript_importmap_integrity_tags if shim),
+      (javascript_importmap_shim_configuration_tag if shim),
       (javascript_importmap_shim_tag if shim),
       javascript_import_module_tag(entry_point)
     ].compact, "\n"
@@ -14,14 +15,21 @@ module Importmap::ImportmapTagsHelper
   # By default, `Rails.application.importmap.to_json(resolver: self)` is used.
   def javascript_inline_importmap_tag(importmap_json = Rails.application.importmap.to_json(resolver: self))
     tag.script importmap_json.html_safe,
-      type: "importmap", "data-turbo-track": "reload", nonce: request&.content_security_policy_nonce
+      type: "importmap-shim", "data-turbo-track": "reload", nonce: request&.content_security_policy_nonce
   end
 
-  # Configure es-modules-shim with nonce support if the application is using a content security policy.
-  def javascript_importmap_shim_nonce_configuration_tag
+  # Configure es-modules-shim with nonce support if the application is using a content security policy, and/or with integrity enforcement enabled, if any integrity shas are present.
+  def javascript_importmap_shim_configuration_tag
+    configuration = {}
+    tag_options = { type: "esms-options" }
     if request&.content_security_policy
-      tag.script({ nonce: request.content_security_policy_nonce }.to_json.html_safe,
-        type: "esms-options", nonce: request.content_security_policy_nonce)
+      configuration[:nonce] = tag_options[:nonce] = request.content_security_policy_nonce
+    end
+    if Rails.application.importmap.integrities(resolver: self).any?
+      configuration[:enforceIntegrity] = true
+    end
+    if configuration.any?
+      tag.script(configuration.to_json.html_safe, **tag_options)
     end
   end
 
@@ -35,7 +43,7 @@ module Importmap::ImportmapTagsHelper
   def javascript_import_module_tag(*module_names)
     imports = Array(module_names).collect { |m| %(import "#{m}") }.join("\n")
     tag.script imports.html_safe,
-      type: "module", nonce: request&.content_security_policy_nonce
+      type: "module-shim", nonce: request&.content_security_policy_nonce
   end
 
   # Link tags for preloading all modules marked as preload: true in the `importmap`
@@ -49,6 +57,12 @@ module Importmap::ImportmapTagsHelper
   def javascript_module_preload_tag(*paths)
     safe_join(Array(paths).collect { |path|
       tag.link rel: "modulepreload", href: path, nonce: request&.content_security_policy_nonce
+    }, "\n")
+  end
+
+  def javascript_importmap_integrity_tags(importmap = Rails.application.importmap)
+    safe_join(Array(importmap.integrities(resolver: self)).collect { |m, integrity|
+      tag.link rel: "modulepreload-shim", href: m, integrity: integrity
     }, "\n")
   end
 end

--- a/lib/importmap/commands.rb
+++ b/lib/importmap/commands.rb
@@ -13,16 +13,19 @@ class Importmap::Commands < Thor
   option :env, type: :string, aliases: :e, default: "production"
   option :from, type: :string, aliases: :f, default: "jspm"
   option :download, type: :boolean, aliases: :d, default: false
+  option :integrity, type: :boolean, aliases: :i, default: false
   def pin(*packages)
     if imports = packager.import(*packages, env: options[:env], from: options[:from])
       imports.each do |package, url|
         if options[:download]
           puts %(Pinning "#{package}" to #{packager.vendor_path}/#{package}.js via download from #{url})
           packager.download(package, url)
-          pin = packager.vendored_pin_for(package, url)
+          integrity = packager.calculate_integrity(package: package) if options[:integrity]
+          pin = packager.vendored_pin_for(package, url, integrity: integrity)
         else
           puts %(Pinning "#{package}" to #{url})
-          pin = packager.pin_for(package, url)
+          integrity = packager.calculate_integrity(url: url) if options[:integrity]
+          pin = packager.pin_for(package, url, integrity: integrity)
         end
 
         if packager.packaged?(package)

--- a/test/dummy/app/assets/javascripts/application.js
+++ b/test/dummy/app/assets/javascripts/application.js
@@ -1,0 +1,1 @@
+console.log("Hello world")

--- a/test/dummy/config/importmap.rb
+++ b/test/dummy/config/importmap.rb
@@ -1,4 +1,4 @@
 pin_all_from "app/assets/javascripts"
 
-pin "md5", to: "https://cdn.skypack.dev/md5", preload: true
+pin "md5", to: "https://cdn.skypack.dev/md5", preload: true, integrity: "sha384-Z4mBXx9MNus/5gJoxoUytBtq6JEV77AuAnUdPedFRPuIB+puUQ2EE6LsC8bY9CBR"
 pin "not_there", to: "nowhere.js"

--- a/test/importmap_tags_helper_test.rb
+++ b/test/importmap_tags_helper_test.rb
@@ -20,13 +20,13 @@ class Importmap::ImportmapTagsHelperTest < ActionView::TestCase
   end
 
   test "javascript_importmap_tags with and without shim" do
-    assert_match /shim/, javascript_importmap_tags("application")
-    assert_no_match /shim/, javascript_importmap_tags("application", shim: false)
+    assert_match /es-module-shims/, javascript_importmap_tags("application")
+    assert_no_match /es-module-shims/, javascript_importmap_tags("application", shim: false)
   end
 
   test "javascript_inline_importmap_tag" do
     assert_match \
-      %r{<script type="importmap" data-turbo-track="reload">{\n  \"imports\": {\n    \"md5\": \"https://cdn.skypack.dev/md5\",\n    \"not_there\": \"/nowhere.js\"\n  }\n}</script>},
+      %r{<script type="importmap-shim" data-turbo-track="reload">{\n  \"imports\": {\n    \"md5\": \"https://cdn.skypack.dev/md5\",\n    \"not_there\": \"/nowhere.js\",\n    \"application\": \"/application.js\"\n  }\n}</script>},
       javascript_inline_importmap_tag
   end
 
@@ -48,7 +48,7 @@ class Importmap::ImportmapTagsHelperTest < ActionView::TestCase
     @request = FakeRequest.new("iyhD0Yc0W+c=")
 
     assert_match /nonce="iyhD0Yc0W\+c="/, javascript_inline_importmap_tag
-    assert_match /nonce="iyhD0Yc0W\+c="/, javascript_importmap_shim_nonce_configuration_tag
+    assert_match /nonce="iyhD0Yc0W\+c="/, javascript_importmap_shim_configuration_tag
     assert_match /nonce="iyhD0Yc0W\+c="/, javascript_importmap_shim_tag
     assert_match /nonce="iyhD0Yc0W\+c="/, javascript_import_module_tag("application")
     assert_match /nonce="iyhD0Yc0W\+c="/, javascript_importmap_module_preload_tags
@@ -62,11 +62,23 @@ class Importmap::ImportmapTagsHelperTest < ActionView::TestCase
     importmap.pin "bar", preload: false
     importmap_html = javascript_importmap_tags("foo", importmap: importmap)
 
-    assert_includes importmap_html, %{<script type="importmap" data-turbo-track="reload">}
+    assert_includes importmap_html, %{<script type="importmap-shim" data-turbo-track="reload">}
     assert_includes importmap_html, %{"foo": "/foo.js"}
     assert_includes importmap_html, %{"bar": "/bar.js"}
     assert_includes importmap_html, %{<link rel="modulepreload" href="/foo.js">}
     refute_includes importmap_html, %{<link rel="modulepreload" href="/bar.js">}
-    assert_includes importmap_html, %{<script type="module">import "foo"</script>}
+    assert_includes importmap_html, %{<script type="module-shim">import "foo"</script>}
+  end
+
+  test "integrity shas are specified and integrity shim option is enabled if any pin has integrity" do
+    assert_dom_equal \
+      <<~HTML.chomp,
+        <link rel="modulepreload-shim" href="https://cdn.skypack.dev/md5" integrity="sha384-Z4mBXx9MNus/5gJoxoUytBtq6JEV77AuAnUdPedFRPuIB+puUQ2EE6LsC8bY9CBR">
+        <link rel="modulepreload-shim" href="/application.js" integrity="sha256-rtJxuS0yqe/8JI4gvbQHf7+EKTGA/a8Uk+J1wyIEBrE=">
+      HTML
+      javascript_importmap_integrity_tags
+    assert_dom_equal \
+      %(<script type="esms-options">{"enforceIntegrity":true}</script>),
+      javascript_importmap_shim_configuration_tag
   end
 end

--- a/test/importmap_test.rb
+++ b/test/importmap_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "minitest/mock"
 
 class ImportmapTest < ActiveSupport::TestCase
   def setup
@@ -8,6 +9,7 @@ class ImportmapTest < ActiveSupport::TestCase
         pin "editor", to: "rich_text.js"
         pin "not_there", to: "nowhere.js"
         pin "md5", to: "https://cdn.skypack.dev/md5", preload: true
+        pin "ciphers", to: "https://cdn.skypack.dev/ciphers", integrity: "sha384-/ZZpnm1H4nw1IuQda2fzk2EBThQwZz5aV3x84D3SqZMUCou2TU6WHhIjX0eSBK6S"
 
         pin_all_from "app/javascript/controllers", under: "controllers", preload: true
         pin_all_from "app/javascript/spina/controllers", under: "controllers/spina", preload: true
@@ -32,6 +34,12 @@ class ImportmapTest < ActiveSupport::TestCase
 
   test "remote pin is not digest stamped" do
     assert_equal "https://cdn.skypack.dev/md5", generate_importmap_json["imports"]["md5"]
+  end
+
+  test "remote with integrity is propagated" do
+    resolver = Minitest::Mock.new
+    def resolver.path_to_asset(a); a; end
+    assert_equal "sha384-/ZZpnm1H4nw1IuQda2fzk2EBThQwZz5aV3x84D3SqZMUCou2TU6WHhIjX0eSBK6S", @importmap.integrities(resolver: resolver)["https://cdn.skypack.dev/ciphers"]
   end
 
   test "directory pin mounted under matching subdir maps all files" do


### PR DESCRIPTION
## Summary

This is a proof-of-concept for adding optional Sub-Resource Integrity support via a new `--integrity` command line option, and a new `:integrity` key in `config/importmap.rb`:

`bin/importmap pin md5 --integrity`

When this option is enabled, the SRI checksum is calculated and added to config/importmap.rb:

`pin "md5", to: "https://cdn.jsdelivr.net/npm/md5@2.3.0/md5.js", integrity: "sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC"`

Which ultimately adds it to the HTML importmap, with two ESMS options enabled:

```html
<script type="esms-options">{ "polyfillEnable": true, "enforceIntegrity": true }</script>
<script type="importmap-shim">...</script>
<link rel="modulepreload-shim" href="https://cdn.jsdelivr.net/npm/md5@2.3.0/md5.js" integrity="sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC" />
```
More discussion here: https://github.com/rails/importmap-rails/issues/122

## Drawbacks
* Note that this requires the `polyfillEnable: true` option to be turned on so that the shim is used for ALL clients. Otherwise, this integrity checking is bypassed when using native implementations, e.g. Chrome. So there is a performance/security trade-off here.
* The previous also requires that we append "-shim" to the relevant `script[type]` and `link[rel]` attributes. This breaks some other tooling that is looking for `script[type='importmap']` exactly, e.g. `{ eagerLoadControllersFrom } from "@hotwired/stimulus-loading"`.

## TODO:
* More tests. This is mostly a proof-of-concept spike with only a few narrow unit tests, so I want to make sure that this plays well in all contexts.
* Propshaft integration. Currently failing in CI.
* Investigate whether or not its possible to work with ESMS to avoid appending "-shim" to `script[type]` and `link[rel]` attributes?  ESMS has progressed since I dove deep last year, maybe this has changed.
* Add documentation

Thoughts?