### PR TITLE
Use non-subshell `system` variant in installer

### DIFF
--- a/lib/tasks/importmap_tasks.rake
+++ b/lib/tasks/importmap_tasks.rake
@@ -1,6 +1,6 @@
 namespace :importmap do
   desc "Setup Importmap for the app"
   task :install do
-    system "#{RbConfig.ruby} ./bin/rails app:template LOCATION=#{File.expand_path("../install/install.rb",  __dir__)}"
+    system RbConfig.ruby, "./bin/rails", "app:template", "LOCATION=#{File.expand_path("../install/install.rb", __dir__)}"
   end
 end


### PR DESCRIPTION
This prevents an error when the template path contains characters that should be escaped.  For example, if the `importmap-rails` gem is installed in a directory that has whitespace characters in its path. Avoiding a subshell is also more performant.