### PR TITLE
Test `json` command using Minitest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,3 @@ jobs:
       - name: Run tests
         run: |
           bundle exec rake
-
-      - name: Ensure json command prints an importmap
-        run: |
-          cp lib/install/bin/importmap test/dummy/bin/importmap
-          test/dummy/bin/importmap json | jq -e .imports

--- a/test/commands_test.rb
+++ b/test/commands_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+require "json"
+
+class CommandsTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::Isolation
+
+  setup do
+    @tmpdir = Dir.mktmpdir
+    FileUtils.cp_r("#{__dir__}/dummy", @tmpdir)
+    Dir.chdir("#{@tmpdir}/dummy")
+    FileUtils.cp("#{__dir__}/../lib/install/bin/importmap", "bin")
+  end
+
+  teardown do
+    FileUtils.remove_entry(@tmpdir) if @tmpdir
+  end
+
+  test "json command prints JSON with imports" do
+    out, err = run_importmap_command("json")
+    assert_includes JSON.parse(out), "imports"
+  end
+
+  private
+    def run_importmap_command(command, *args)
+      capture_subprocess_io { system("bin/importmap", command, *args, exception: true) }
+    end
+end


### PR DESCRIPTION
Follow-up to a2e563218399f31bf8a34d8423feb6d2a5846660.

This replaces the GitHub Actions-based test for the `json` command with a typical Minitest test so that it can be tested locally as well.