### PR TITLE
Changes the default for preloading pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ pin "md5", to: "https://cdn.jsdelivr.net/npm/md5@2.3.0/md5.js"
 ...
 ```
 
+You can preload all your pins by default by setting `config.importmap.preload_by_default` in any environment file to `true`.
+
 ## Composing import maps
 
 By default, Rails loads import map definition from the application's `config/importmap.rb` to the `Importmap::Map` object available at `Rails.application.importmap`.

--- a/lib/importmap/engine.rb
+++ b/lib/importmap/engine.rb
@@ -10,6 +10,7 @@ module Importmap
     config.importmap.sweep_cache = Rails.env.development? || Rails.env.test?
     config.importmap.cache_sweepers = []
     config.importmap.rescuable_asset_errors = []
+    config.importmap.preload_by_default = false
 
     config.autoload_once_paths = %W( #{root}/app/helpers )
 

--- a/lib/importmap/map.rb
+++ b/lib/importmap/map.rb
@@ -25,12 +25,12 @@ class Importmap::Map
     self
   end
 
-  def pin(name, to: nil, preload: false)
+  def pin(name, to: nil, preload: Rails.application.config.importmap.preload_by_default)
     clear_cache
     @packages[name] = MappedFile.new(name: name, path: to || "#{name}.js", preload: preload)
   end
 
-  def pin_all_from(dir, under: nil, to: nil, preload: false)
+  def pin_all_from(dir, under: nil, to: nil, preload: Rails.application.config.importmap.preload_by_default)
     clear_cache
     @directories[dir] = MappedDir.new(dir: dir, under: under, path: to, preload: preload)
   end

--- a/test/importmap_tags_helper_test.rb
+++ b/test/importmap_tags_helper_test.rb
@@ -69,4 +69,41 @@ class Importmap::ImportmapTagsHelperTest < ActionView::TestCase
     refute_includes importmap_html, %{<link rel="modulepreload" href="/bar.js">}
     assert_includes importmap_html, %{<script type="module">import "foo"</script>}
   end
+
+  test "with preload by default disabled" do
+    with_preload_by_default(false) do
+      importmap = Importmap::Map.new
+      importmap.pin "foo"
+      importmap.pin_all_from "app/javascript/controllers"
+      importmap_html = javascript_importmap_tags("foo", importmap: importmap)
+
+      refute_includes importmap_html, %{<link rel="modulepreload" href="/foo.js">}
+      refute_includes importmap_html, %{<link rel="modulepreload" href="/goodbye_controller.js">}
+    end
+  end
+
+  test "with preload by default enabled" do
+    with_preload_by_default(true) do
+      importmap = Importmap::Map.new
+      importmap.pin "foo"
+      importmap.pin_all_from "app/javascript/controllers"
+      importmap_html = javascript_importmap_tags("foo", importmap: importmap)
+
+      assert_includes importmap_html, %{<link rel="modulepreload" href="/foo.js">}
+      assert_includes importmap_html, %{<link rel="modulepreload" href="/goodbye_controller.js">}
+    end
+  end
+
+  private
+
+  def with_preload_by_default(bool)
+    old_preload_setting = Rails.application.config.importmap.preload_by_default
+
+    begin
+      Rails.application.config.importmap.preload_by_default = bool
+      yield
+    ensure
+      Rails.application.config.importmap.preload_by_default = old_preload_setting
+    end
+  end
 end


### PR DESCRIPTION
Before this PR, you'd have to opt-in to preloading pins. Now you have to opt out for some pins.

If this PR is too big of a breaking change, I could also introduce a setting, which can be toggled in a major release:

```ruby
# engine.rb
config.importmap.preload_by_default = true
```

I'd be happy to adapt 👍