### PR TITLE
Preload all by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,20 +198,20 @@ Just like with a normal pin, you can also update a pin by running the `pin --dow
 
 ## Preloading pinned modules
 
-To avoid the waterfall effect where the browser has to load one file after another before it can get to the deepest nested import, importmap-rails supports [modulepreload links](https://developers.google.com/web/updates/2017/12/modulepreload). Pinned modules can be preloaded by appending `preload: true` to the pin.
+To avoid the waterfall effect where the browser has to load one file after another before it can get to the deepest nested import, importmap-rails uses [modulepreload links](https://developers.google.com/web/updates/2017/12/modulepreload) by default. If you don't want to preload a dependencies, because it'you want to load it on-demand for efficiency, pinned modules can prevent preloading by appending `preload: false` to the pin.
 
 Example:
 
 ```ruby
 # config/importmap.rb
-pin "@github/hotkey", to: "https://ga.jspm.io/npm:@github/hotkey@1.4.4/dist/index.js", preload: true
-pin "md5", to: "https://cdn.jsdelivr.net/npm/md5@2.3.0/md5.js"
+pin "@github/hotkey", to: "vendor/javascript/@github--hotkey.js"
+pin "md5", to: "vendor/javascript/md5.js", preload: false
 
 # app/views/layouts/application.html.erb
 <%= javascript_importmap_tags %>
 
 # will include the following link before the importmap is setup:
-<link rel="modulepreload" href="https://ga.jspm.io/npm:@github/hotkey@1.4.4/dist/index.js">
+<link rel="modulepreload" href="/assets/javascripts/@github--hotkey.js">
 ...
 ```
 
@@ -260,7 +260,7 @@ Pin your js file:
 ```rb
 # config/importmap.rb
 # ... other pins...
-pin "checkout"
+pin "checkout", preload: false
 ```
 
 Import your module on the specific page. Note: you'll likely want to use a `content_for` block on the specifc page/partial, then yield it in your layout.

--- a/lib/importmap/map.rb
+++ b/lib/importmap/map.rb
@@ -25,12 +25,12 @@ class Importmap::Map
     self
   end
 
-  def pin(name, to: nil, preload: false)
+  def pin(name, to: nil, preload: true)
     clear_cache
     @packages[name] = MappedFile.new(name: name, path: to || "#{name}.js", preload: preload)
   end
 
-  def pin_all_from(dir, under: nil, to: nil, preload: false)
+  def pin_all_from(dir, under: nil, to: nil, preload: true)
     clear_cache
     @directories[dir] = MappedDir.new(dir: dir, under: under, path: to, preload: preload)
   end

--- a/test/dummy/config/importmap.rb
+++ b/test/dummy/config/importmap.rb
@@ -1,4 +1,4 @@
 pin_all_from "app/assets/javascripts"
 
 pin "md5", to: "https://cdn.skypack.dev/md5", preload: true
-pin "not_there", to: "nowhere.js"
+pin "not_there", to: "nowhere.js", preload: false

--- a/test/importmap_test.rb
+++ b/test/importmap_test.rb
@@ -4,9 +4,9 @@ class ImportmapTest < ActiveSupport::TestCase
   def setup
     @importmap = Importmap::Map.new.tap do |map|
       map.draw do
-        pin "application"
-        pin "editor", to: "rich_text.js"
-        pin "not_there", to: "nowhere.js"
+        pin "application", preload: false
+        pin "editor", to: "rich_text.js", preload: false
+        pin "not_there", to: "nowhere.js", preload: false
         pin "md5", to: "https://cdn.skypack.dev/md5", preload: true
 
         pin_all_from "app/javascript/controllers", under: "controllers", preload: true


### PR DESCRIPTION
An app has to be very large to benefit from partial/on-demand loading. And that's the only time where you wouldn't want to preload your dependencies, because the cost of water falling would be less than the cost of loading it all. For most applications, you'd rather have zero waterfall by default, and load all your JavaScript up front. So that should be the default.