### PR TITLE
Remove remaining reference in README to the deleted `--download` CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The packages are downloaded to `vendor/javascript`, which you can check into you
 If you later wish to remove a downloaded pin:
 
 ```bash
-./bin/importmap unpin react --download
+./bin/importmap unpin react
 Unpinning and removing "react"
 Unpinning and removing "object-assign"
 ```


### PR DESCRIPTION
The `--download` CLI option was deleted in https://github.com/rails/importmap-rails/pull/217, but it was still being referenced in this sample command in the README.