### PR TITLE
Fix wording in preloading pinned modules docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Unpinning and removing "object-assign"
 
 ## Preloading pinned modules
 
-To avoid the waterfall effect where the browser has to load one file after another before it can get to the deepest nested import, importmap-rails uses [modulepreload links](https://developers.google.com/web/updates/2017/12/modulepreload) by default. If you don't want to preload dependencies, e.g. because you want to load it on-demand for efficiency, pinned modules can prevent preloading by appending `preload: false` to the pin.
+To avoid the waterfall effect where the browser has to load one file after another before it can get to the deepest nested import, importmap-rails uses [modulepreload links](https://developers.google.com/web/updates/2017/12/modulepreload) by default. If you don't want to preload a dependency, because you want to load it on-demand for efficiency, append `preload: false` to the pin.
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Unpinning and removing "object-assign"
 
 ## Preloading pinned modules
 
-To avoid the waterfall effect where the browser has to load one file after another before it can get to the deepest nested import, importmap-rails uses [modulepreload links](https://developers.google.com/web/updates/2017/12/modulepreload) by default. If you don't want to preload a dependencies, because it'you want to load it on-demand for efficiency, pinned modules can prevent preloading by appending `preload: false` to the pin.
+To avoid the waterfall effect where the browser has to load one file after another before it can get to the deepest nested import, importmap-rails uses [modulepreload links](https://developers.google.com/web/updates/2017/12/modulepreload) by default. If you don't want to preload dependencies, e.g. because you want to load it on-demand for efficiency, pinned modules can prevent preloading by appending `preload: false` to the pin.
 
 Example:
 


### PR DESCRIPTION
Reading through the docs again after #218 I noticed the wording seemed to be off in the "Preloading pinned modules" docs section so this is my suggested fix.