### PR TITLE
Update docs with pinning modules from engine/gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,21 @@ And pinning JavaScript modules from the engine:
 pin_all_from File.expand_path("../app/assets/javascripts", __dir__)
 ```
 
+## Pinning modules from engines
+
+To pin a vendored module from a gem, such as `@rails/ujs` from Rails ActionView, we can import the ESM module:
+
+```ruby
+# config/importmap.rb
+pin "@rails/ujs", to: "rails-ujs.esm.js"
+```
+
+Then update the `app/assets/config/manifest.js` file to link it:
+
+```js
+# ...
+//= link rails-ujs.esm.js
+```
 
 ## Selectively importing modules
 


### PR DESCRIPTION
I'm working on ActiveAdmin v4 which uses importmap-rails (separate engine config) and @rails/ujs. I wondered why I had to download the @rails/ujs file from a CDN if the ESM version is already shipped in Rails (ActionView) to begin with. I figured it would help to have a section in the docs to demonstrate how to pin a module and link it, where the module file itself is included in Rails. My use case was for @rails/ujs but this approach should be applicable for activestorage, etc. I'm not sure if the term "vendored" here is appropriate. Would appreciate any review/corrections.