### PR TITLE
Update Impoortmaps::Command#puts_table to be markdown compatible

### DIFF
--- a/lib/importmap/commands.rb
+++ b/lib/importmap/commands.rb
@@ -121,14 +121,13 @@ class Importmap::Commands < Thor
         row.each_with_index.map{ |iterand, index| [lengths[index] || 0, iterand.to_s.length].max }
       end
 
-      puts head = "+" + (column_sizes.map { |s| "-" * (s + 2) }.join('+')) + '+'
+      divider = "|" + (column_sizes.map { |s| "-" * (s + 2) }.join('|')) + '|'
       array.each_with_index do |row, row_number|
         row = row.fill(nil, row.size..(column_sizes.size - 1))
         row = row.each_with_index.map { |v, i| v.to_s + " " * (column_sizes[i] - v.to_s.length) }
         puts "| " + row.join(" | ") + " |"
-        puts head if row_number == 0
+        puts divider if row_number == 0
       end
-      puts head
     end
 end
 


### PR DESCRIPTION
Proposal to make the command table markdown compatible, so it's easier to copy the table and paste directly in any markdown (normally the PR description) and display it with the correct styles.

```shell
➜  dummy git:(main) ✗ bin/importmap outdated
+-------------------+---------+--------+
| Package           | Current | Latest |
+-------------------+---------+--------+
| @rails/request.js | 0.0.6   | 0.0.9  |
+-------------------+---------+--------+
  1 outdated package found
➜  dummy git:(main) ✗ bin/importmap outdated
| Package           | Current | Latest |
|-------------------|---------|--------|
| @rails/request.js | 0.0.6   | 0.0.9  |
  1 outdated package found
```

Also displaying the table here:

Old:
+-------------------+---------+--------+
| Package           | Current | Latest |
+-------------------+---------+--------+
| @rails/request.js | 0.0.6   | 0.0.9  |
+-------------------+---------+--------+

New:
| Package           | Current | Latest |
|-------------------|---------|--------|
| @rails/request.js | 0.0.6   | 0.0.9  |

Another option instead of make this the default is to accept a flag like `--md` to print the table as markdown compatible.