### PR TITLE
Use Thor's print_table to print tables with borders

### DIFF
--- a/importmap-rails.gemspec
+++ b/importmap-rails.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "railties", ">= 6.0.0"
   spec.add_dependency "activesupport", ">= 6.0.0"
   spec.add_dependency "actionpack", ">= 6.0.0"
+  spec.add_dependency "thor", ">= 1.3.0"
 end

--- a/lib/importmap/commands.rb
+++ b/lib/importmap/commands.rb
@@ -70,9 +70,10 @@ class Importmap::Commands < Thor
 
     if vulnerable_packages.any?
       table = [["Package", "Severity", "Vulnerable versions", "Vulnerability"]]
+      table << :separator
       vulnerable_packages.each { |p| table << [p.name, p.severity, p.vulnerable_versions, p.vulnerability] }
 
-      puts_table(table)
+      print_table(table, borders: true)
       vulnerabilities = 'vulnerability'.pluralize(vulnerable_packages.size)
       severities = vulnerable_packages.map(&:severity).tally.sort_by(&:last).reverse
                                       .map { |severity, count| "#{count} #{severity}" }
@@ -91,9 +92,10 @@ class Importmap::Commands < Thor
 
     if outdated_packages.any?
       table = [["Package", "Current", "Latest"]]
+      table << :separator
       outdated_packages.each { |p| table << [p.name, p.current_version, p.latest_version || p.error] }
 
-      puts_table(table)
+      print_table(table, borders: true)
       packages = 'package'.pluralize(outdated_packages.size)
       puts "  #{outdated_packages.size} outdated #{packages} found"
 
@@ -126,21 +128,6 @@ class Importmap::Commands < Thor
       File.open(path, "w") do |file|
         with_lines_removed.each { |line| file.write(line) }
       end
-    end
-
-    def puts_table(array)
-      column_sizes = array.reduce([]) do |lengths, row|
-        row.each_with_index.map{ |iterand, index| [lengths[index] || 0, iterand.to_s.length].max }
-      end
-
-      puts head = "+" + (column_sizes.map { |s| "-" * (s + 2) }.join('+')) + '+'
-      array.each_with_index do |row, row_number|
-        row = row.fill(nil, row.size..(column_sizes.size - 1))
-        row = row.each_with_index.map { |v, i| v.to_s + " " * (column_sizes[i] - v.to_s.length) }
-        puts "| " + row.join(" | ") + " |"
-        puts head if row_number == 0
-      end
-      puts head
     end
 end
 


### PR DESCRIPTION
Thor 1.3.0 supports printing tables with borders. There's no need to implement it in importmap-rails.