### PR TITLE
Add redownload command

### DIFF
--- a/lib/importmap/commands.rb
+++ b/lib/importmap/commands.rb
@@ -46,6 +46,13 @@ class Importmap::Commands < Thor
     end
   end
 
+  desc "redownload", "Force download every package, even if the required versions are already downloaded"
+  def redownload
+    packages = npm.packages_with_versions.map { |package| package.join("@") }
+
+    pin packages
+  end
+
   desc "json", "Show the full importmap in json"
   def json
     require Rails.root.join("config/environment")


### PR DESCRIPTION
## Description

Now that [`pin` always downloads](https://github.com/rails/importmap-rails/pull/217), I believe there should be a command to re-download existing packages. This command would be particularly useful in scenarios like the one I recently encountered. In such cases, projects that previously used dependencies from a CDN, and have updated the gem, might want to transfer everything to a local folder. This new command could facilitate this process.

However, I'm still uncertain about one aspect: the pin command accepts env and from parameters, and I'm not sure if the env is represented in some way in the URL. This might require additional coding. Rather than using packages_with_versions, it may be more effective to pull the package name and URL and download from there, or to retrieve the package, version, and provider, and install from that source.

The purpose of this PR is to initiate a discussion on whether this feature is valuable. If changes are needed, I am ready to continue working on it.