### PR TITLE
Add package information in vendored package file

### DIFF
--- a/lib/importmap/packager.rb
+++ b/lib/importmap/packager.rb
@@ -113,14 +113,16 @@ class Importmap::Packager
       response = Net::HTTP.get_response(URI(url))
 
       if response.code == "200"
-        save_vendored_package(package, response.body)
+        save_vendored_package(package, url, response.body)
       else
         handle_failure_response(response)
       end
     end
 
-    def save_vendored_package(package, source)
+    def save_vendored_package(package, url, source)
       File.open(vendored_package_path(package), "w+") do |vendored_package|
+        vendored_package.write "// #{package}#{extract_package_version_from(url)} downloaded from #{url}\n\n"
+
         vendored_package.write remove_sourcemap_comment_from(source).force_encoding("UTF-8")
       end
     end

--- a/test/packager_integration_test.rb
+++ b/test/packager_integration_test.rb
@@ -29,12 +29,17 @@ class Importmap::PackagerIntegrationTest < ActiveSupport::TestCase
         Rails.root.join("config/importmap.rb"),
         vendor_path: Pathname.new(vendor_dir)
 
-      @packager.download("@github/webauthn-json",
-        "https://ga.jspm.io/npm:@github/webauthn-json@0.5.7/dist/main/webauthn-json.js")
-      assert File.exist?(Pathname.new(vendor_dir).join("@github--webauthn-json.js"))
+      package_url = "https://ga.jspm.io/npm:@github/webauthn-json@0.5.7/dist/main/webauthn-json.js"
+      @packager.download("@github/webauthn-json", package_url)
+      vendored_package_file = Pathname.new(vendor_dir).join("@github--webauthn-json.js")
+      assert File.exist?(vendored_package_file)
+      assert_equal "// @github/webauthn-json@0.5.7 downloaded from #{package_url}", File.readlines(vendored_package_file).first.strip
 
-      @packager.download("react", "https://ga.jspm.io/npm:react@17.0.2/index.js")
-      assert File.exist?(Pathname.new(vendor_dir).join("react.js"))
+      package_url = "https://ga.jspm.io/npm:react@17.0.2/index.js"
+      vendored_package_file = Pathname.new(vendor_dir).join("react.js")
+      @packager.download("react", package_url)
+      assert File.exist?(vendored_package_file)
+      assert_equal "// react@17.0.2 downloaded from #{package_url}", File.readlines(vendored_package_file).first.strip
       
       @packager.remove("react")
       assert_not File.exist?(Pathname.new(vendor_dir).join("react.js"))


### PR DESCRIPTION
## Description

Now that the packages are downloaded by default, apart from the output of the `pin` command we lose the track of the version and from where the package was downloaded. To track the version the solution was use a comment in bin/importmap next to the package version but nothing for the package origin so the proposal is add a comment in the first line of the downloaded package displaying the package name, version and from where it was downloaded.

![Screenshot 2024-01-05 at 14 46 38](https://github.com/rails/importmap-rails/assets/16840674/b92e6152-9824-4d9a-9c23-49ff0387a9da)
