### PR TITLE
Update default provider to use `jspm.io` instead of `jspm`

### DIFF
--- a/lib/importmap/packager.rb
+++ b/lib/importmap/packager.rb
@@ -19,10 +19,10 @@ class Importmap::Packager
 
   def import(*packages, env: "production", from: "jspm")
     response = post_json({
-      "install"      => Array(packages), 
+      "install"      => Array(packages),
       "flattenScope" => true,
       "env"          => [ "browser", "module", env ],
-      "provider"     => from.to_s,
+      "provider"     => normalize_provider(from)
     })
 
     case response.code
@@ -69,6 +69,10 @@ class Importmap::Packager
       raise HTTPError, "Unexpected transport error (#{error.class}: #{error.message})"
     end
 
+    def normalize_provider(name)
+      name.to_s == "jspm" ? "jspm.io" : name.to_s
+    end
+
     def extract_parsed_imports(response)
       JSON.parse(response.body).dig("map", "imports")
     end
@@ -80,7 +84,7 @@ class Importmap::Packager
         raise HTTPError, "Unexpected response code (#{response.code})"
       end
     end
-  
+
     def parse_service_error(response)
       JSON.parse(response.body.to_s)["error"]
     rescue JSON::ParserError


### PR DESCRIPTION
Coming from https://github.com/basecamp/local_time/issues/113#issuecomment-1891982065

I realized the HTTP request in `Importmap::Packager#import` was returning HTTP401:

```
Code:
401

Body:
{"error":"Error: No provider named \"jspm\" has been defined."}
```

This matches the behavior of a test that's currently failing:

```sh
❯ bin/test test/packager_integration_test.rb

Error:
Importmap::PackagerIntegrationTest#test_successful_import_against_live_service:
NoMethodError: undefined method `[]' for nil:NilClass
    /Users/jose/my_repos/importmap-rails/test/packager_integration_test.rb:8:in `block in <class:PackagerIntegrationTest>'


bin/test /Users/jose/my_repos/importmap-rails/test/packager_integration_test.rb:7
```

This happens because `Importmap::Packager#import` returns `nil` when the HTTP response is `401`: https://github.com/rails/importmap-rails/blob/be74dead314957833f5d09e05a8daaa3526a964b/lib/importmap/packager.rb#L28-L32


Per https://jspm.org/cdn/api#download, the accepted provider options are `jspm.io | jsdelivr | unpkg` — So the fix should be as simple as using `jspm.io` instead of `jspm`.

All tests pass after this change.

Possibly related: https://github.com/jspm/generator/issues/274