### PR TITLE
Download all the files associated with a package from a CDN

### DIFF
--- a/lib/importmap/package.rb
+++ b/lib/importmap/package.rb
@@ -1,4 +1,8 @@
 class Importmap::Package
+  Error        = Class.new(StandardError)
+  HTTPError    = Class.new(Error)
+  ServiceError = Error.new(Error)
+
   attr_reader :base_url, :main_url, :package_name
 
   def initialize(

--- a/lib/importmap/package.rb
+++ b/lib/importmap/package.rb
@@ -36,18 +36,18 @@ class Importmap::Package
     @packager.remove_package_from_importmap(@package_name)
   end
 
-  def vendored_pin
-    filename = vendored_package_path_for_file(@main_file)
-    version  = extract_package_version_from(@main_url)
-
-    %(pin "#{package_name}", to: "#{filename}" # #{version})
-  end
-
   def vendored_package_folder
     @packager.vendor_path.join(folder_name)
   end
 
   private
+    def vendored_pin
+      filename = "#{package_name}/#{@main_file}"
+      version  = extract_package_version_from(@main_url)
+
+      %(pin "#{package_name}", to: "#{filename}" # #{version})
+    end
+
     def download_file(file)
       response = Net::HTTP.get_response(URI("#{base_url}/#{file}"))
 

--- a/lib/importmap/package.rb
+++ b/lib/importmap/package.rb
@@ -1,0 +1,117 @@
+class Importmap::Package
+  attr_reader :base_url, :main_url, :package_name
+
+  def initialize(
+    unfiltered_dependencies:,
+    package_name:,
+    main_url:,
+    packager:
+  )
+    @unfiltered_dependencies = unfiltered_dependencies
+    @package_name = package_name
+    @main_url = main_url
+    @packager = packager
+
+    @base_url = extract_base_url_from(main_url)
+
+    dependencies = unfiltered_dependencies.select { _1.start_with?(base_url) }
+    @dependency_files = dependencies.map { _1[(base_url.size + 1)..] } # @main_file is included in this list
+
+    @main_file = main_url[(base_url.size + 1)..]
+  end
+
+  def download
+    @packager.ensure_vendor_directory_exists
+    remove_existing_package_files
+
+    @dependency_files.each do |file|
+      download_file(file)
+    end
+
+    @packager.pin_package_in_importmap(@package_name, vendored_pin)
+  end
+
+  def remove
+    remove_existing_package_files
+    @packager.remove_package_from_importmap(@package_name)
+  end
+
+  def vendored_pin
+    filename = vendored_package_path_for_file(@main_file)
+    version  = extract_package_version_from(@main_url)
+
+    %(pin "#{package_name}", to: "#{filename}" # #{version})
+  end
+
+  def vendored_package_folder
+    @packager.vendor_path.join(folder_name)
+  end
+
+  private
+    def download_file(file)
+      response = Net::HTTP.get_response(URI("#{base_url}/#{file}"))
+
+      if response.code == "200"
+        save_vendored_file(file, response.body)
+      else
+        handle_failure_response(response)
+      end
+    end
+
+    def save_vendored_file(file, source)
+      url = "#{base_url}/#{file}"
+      file_name = vendored_package_path_for_file(file)
+      ensure_parent_directories_exist_for(file_name)
+      File.open(file_name, "w+") do |vendored_file|
+        vendored_file.write "// #{package_name}#{extract_package_version_from(url)}/#{file} downloaded from #{url}\n\n"
+
+        vendored_file.write remove_sourcemap_comment_from(source).force_encoding("UTF-8")
+      end
+    end
+
+    def ensure_parent_directories_exist_for(file)
+      dir_name = File.dirname(file)
+
+      unless File.directory?(dir_name)
+        FileUtils.mkdir_p(dir_name)
+      end
+    end
+
+    def remove_sourcemap_comment_from(source)
+      source.gsub(/^\/\/# sourceMappingURL=.*/, "")
+    end
+
+    def vendored_package_path_for_file(file)
+      vendored_package_folder.join(file)
+    end
+
+    def handle_failure_response(response)
+      if error_message = parse_service_error(response)
+        raise ServiceError, error_message
+      else
+        raise HTTPError, "Unexpected response code (#{response.code})"
+      end
+    end
+
+    def parse_service_error(response)
+      JSON.parse(response.body.to_s)["error"]
+    rescue JSON::ParserError
+      nil
+    end
+
+    def remove_existing_package_files
+      FileUtils.rm_rf vendored_package_folder
+    end
+
+    def folder_name
+      @package_name.gsub("/", "--")
+    end
+
+    def extract_base_url_from(url)
+      url.match(/^.+@\d+\.\d+\.\d+/)&.to_a&.first
+    end
+
+    def extract_package_version_from(url)
+      url.match(/@\d+\.\d+\.\d+/)&.to_a&.first
+    end
+end

--- a/lib/importmap/package.rb
+++ b/lib/importmap/package.rb
@@ -46,7 +46,7 @@ class Importmap::Package
 
   private
     def vendored_pin
-      filename = "#{package_name}/#{@main_file}"
+      filename = "#{folder_name}/#{@main_file}"
       version  = extract_package_version_from(@main_url)
 
       %(pin "#{package_name}", to: "#{filename}" # #{version})

--- a/test/packager_integration_test.rb
+++ b/test/packager_integration_test.rb
@@ -109,6 +109,20 @@ class Importmap::PackagerIntegrationTest < ActiveSupport::TestCase
       packages.each(&:remove)
 
       assert_equal "", importmap_path.read
+
+      packages  = @packager.import("tippy.js@6.3.7")
+      packages.each(&:download)
+
+      importmap = <<~RB
+        pin "tippy.js", to: "tippy.js/dist/tippy.esm.js" # @6.3.7
+        pin "@popperjs/core", to: "@popperjs--core/lib/index.js" # @2.11.8
+      RB
+
+      assert_equal importmap, importmap_path.read
+
+      packages.each(&:remove)
+
+      assert_equal "", importmap_path.read
     end
   end
 end

--- a/test/packager_integration_test.rb
+++ b/test/packager_integration_test.rb
@@ -5,7 +5,13 @@ class Importmap::PackagerIntegrationTest < ActiveSupport::TestCase
   setup { @packager = Importmap::Packager.new(Rails.root.join("config/importmap.rb")) }
 
   test "successful import against live service" do
-    assert_equal "https://ga.jspm.io/npm:react@17.0.2/index.js", @packager.import("react@17.0.2")["react"]
+    results = @packager.import("react@17.0.2")
+
+    react_result = results.find { _1.package_name == "react" }
+    object_assign_result = results.find { _1.package_name == "object-assign" }
+
+    assert_equal("https://ga.jspm.io/npm:react@17.0.2/index.js", react_result.main_url)
+    assert_equal("https://ga.jspm.io/npm:object-assign@4.1.1/index.js", object_assign_result.main_url)
   end
 
   test "missing import against live service" do
@@ -25,24 +31,84 @@ class Importmap::PackagerIntegrationTest < ActiveSupport::TestCase
 
   test "successful downloads from live service" do
     Dir.mktmpdir do |vendor_dir|
-      @packager = Importmap::Packager.new \
-        Rails.root.join("config/importmap.rb"),
-        vendor_path: Pathname.new(vendor_dir)
+      importmap_path = Pathname.new(vendor_dir).join("importmap.rb")
 
-      package_url = "https://ga.jspm.io/npm:@github/webauthn-json@0.5.7/dist/main/webauthn-json.js"
-      @packager.download("@github/webauthn-json", package_url)
-      vendored_package_file = Pathname.new(vendor_dir).join("@github--webauthn-json.js")
-      assert File.exist?(vendored_package_file)
-      assert_equal "// @github/webauthn-json@0.5.7 downloaded from #{package_url}", File.readlines(vendored_package_file).first.strip
+      File.new(importmap_path, "w").close
 
-      package_url = "https://ga.jspm.io/npm:react@17.0.2/index.js"
-      vendored_package_file = Pathname.new(vendor_dir).join("react.js")
-      @packager.download("react", package_url)
-      assert File.exist?(vendored_package_file)
-      assert_equal "// react@17.0.2 downloaded from #{package_url}", File.readlines(vendored_package_file).first.strip
-      
-      @packager.remove("react")
-      assert_not File.exist?(Pathname.new(vendor_dir).join("react.js"))
+      @packager = Importmap::Packager.new(
+        importmap_path,
+        vendor_path: Pathname.new(vendor_dir),
+      )
+
+      packages  = @packager.import("react@17.0.2")
+      packages.each(&:download)
+
+      vendored_file = Pathname.new(vendor_dir).join("react/cjs/react.production.min.js")
+      assert_equal "// react@17.0.2/cjs/react.production.min.js downloaded from https://ga.jspm.io/npm:react@17.0.2/cjs/react.production.min.js",
+        File.readlines(vendored_file).first.strip
+      vendored_file = Pathname.new(vendor_dir).join("react/index.js")
+      assert_equal "// react@17.0.2/index.js downloaded from https://ga.jspm.io/npm:react@17.0.2/index.js",
+        File.readlines(vendored_file).first.strip
+      vendored_file = Pathname.new(vendor_dir).join("object-assign/index.js")
+      assert_equal "// object-assign@4.1.1/index.js downloaded from https://ga.jspm.io/npm:object-assign@4.1.1/index.js",
+        File.readlines(vendored_file).first.strip
+
+      packages.each(&:remove)
+
+      assert_not File.exist?(Pathname.new(vendor_dir).join("react/cjs/react.production.min.js"))
+      assert_not File.exist?(Pathname.new(vendor_dir).join("react/index.js"))
+      assert_not File.exist?(Pathname.new(vendor_dir).join("object-assign/index.js"))
+
+      packages  = @packager.import("@github/webauthn-json@0.5.7")
+      packages.each(&:download)
+
+      vendored_file = Pathname.new(vendor_dir).join("@github--webauthn-json/dist/main/webauthn-json.js")
+      assert_equal "// @github/webauthn-json@0.5.7/dist/main/webauthn-json.js downloaded from https://ga.jspm.io/npm:@github/webauthn-json@0.5.7/dist/main/webauthn-json.js",
+        File.readlines(vendored_file).first.strip
+
+      packages.each(&:remove)
+
+      assert_not File.exist?(Pathname.new(vendor_dir).join("webauthn-json/dist/main/webauthn-json.js"))
+
+      packages  = @packager.import("tippy.js@6.3.7")
+      packages.each(&:download)
+
+      assert File.exist?(Pathname.new(vendor_dir).join("@popperjs--core/lib/dom-utils/getWindow.js"))
+      assert File.exist?(Pathname.new(vendor_dir).join("@popperjs--core/lib/index.js"))
+      assert File.exist?(Pathname.new(vendor_dir).join("tippy.js/dist/tippy.esm.js"))
+
+      packages.each(&:remove)
+
+      assert_not File.exist?(Pathname.new(vendor_dir).join("@popperjs--core/lib/dom-utils/getWindow.js"))
+      assert_not File.exist?(Pathname.new(vendor_dir).join("@popperjs--core/lib/index.js"))
+      assert_not File.exist?(Pathname.new(vendor_dir).join("tippy.js/dist/tippy.esm.js"))
+    end
+  end
+
+  test "successful importmap.rb updates from live service" do
+    Dir.mktmpdir do |vendor_dir|
+      importmap_path = Pathname.new(vendor_dir).join("importmap.rb")
+
+      File.new(importmap_path, "w").close
+
+      @packager = Importmap::Packager.new(
+        importmap_path,
+        vendor_path: Pathname.new(vendor_dir),
+      )
+
+      packages  = @packager.import("react@17.0.2")
+      packages.each(&:download)
+
+      importmap = <<~RB
+        pin "react", to: "#{vendor_dir}/react/index.js" # @17.0.2
+        pin "object-assign", to: "#{vendor_dir}/object-assign/index.js" # @4.1.1
+      RB
+
+      assert_equal importmap, importmap_path.read
+
+      packages.each(&:remove)
+
+      assert_equal "", importmap_path.read
     end
   end
 end

--- a/test/packager_integration_test.rb
+++ b/test/packager_integration_test.rb
@@ -100,8 +100,8 @@ class Importmap::PackagerIntegrationTest < ActiveSupport::TestCase
       packages.each(&:download)
 
       importmap = <<~RB
-        pin "react", to: "#{vendor_dir}/react/index.js" # @17.0.2
-        pin "object-assign", to: "#{vendor_dir}/object-assign/index.js" # @4.1.1
+        pin "react", to: "react/index.js" # @17.0.2
+        pin "object-assign", to: "object-assign/index.js" # @4.1.1
       RB
 
       assert_equal importmap, importmap_path.read

--- a/test/packager_single_quotes_test.rb
+++ b/test/packager_single_quotes_test.rb
@@ -16,7 +16,7 @@ class Importmap::PackagerSingleQuotesTest < ActiveSupport::TestCase
   end
 
   test "remove package with single quotes" do
-    assert @packager.remove("md5")
+    assert @packager.remove_package_from_importmap("md5")
     assert_not @packager.packaged?("md5")
   end
 end


### PR DESCRIPTION
- Related https://github.com/rails/importmap-rails/pull/217#issuecomment-1906044892
- Closes https://github.com/rails/importmap-rails/issues/153
- Closes https://github.com/rails/importmap-rails/issues/91

## The main focus
The main focus of this PR is to resolve the issue around packages which are comprised of multiple commands. Before this change, importmap-rails only looked for the entrypoint js file and downloaded that. When it was pinning CDN links, this worked just fine because browsers would be able to resolve the relative imports inside the CDN correctly.

Now that we are downloading the entrypoint and it's hosted on our server's Domains, when the browser tries to perform a relative import, it's unable to find the file.

The solution to this problem is to download all the supporting files for each package.

## My choice of API
To accomplish this, there were two main options:
1. Firstly, we could make use of the new [download API](https://jspm.org/cdn/api#download) as suggested by [DHH](https://github.com/rails/importmap-rails/pull/217#issuecomment-1906044892)
   Looking into this API it turns out that it was returning far more files than what was necessary. It appears to be providing all the files that are not included in the .npmignore file.
   
   In an ideal world, we would only download files that get used by the library.
2. My second option was to use the `staticDeps` and `dynamicDeps` properties provided by the [generate API](https://jspm.org/cdn/api#generator) that we are already using.
  These properties only included the files that get imported by the JS libraries and as we already make this API call, it seemed ideal to make use of it.

## The new package class
While implementing the new downloads, I found that the download logic was very interwoven with the packager logic and I found what I think is a fairly reasonable division of responsibility, where a package is responsible for resolving the folder names and doing the downloading and removals, and a packager is responsible for manipulating the importmap.rb.

I'd be interested in hearing about people's thoughts on this and would be more than happy to squash it back down into the packager class if we're not ready to take on a new abstraction.

## OK - so I've got a folder of downloaded JS but my browser is failing to import the modules
The big culprit here is the fingerprinting/digesting done by sprockets and propshaft.

The issue that we run into is how relative imports are handled. When a browser has a relative import, it will resolve the URL relative to the current file. Both sprockets and propshaft however have a fingerprint appended to the end of all JS files when they're served but don't update the import statements in the JS. This results in a situation where we have a file in our filesystem in the right location with the right name, but propshaft refuses to server it.

Even though it does mean that its currently not much of an improvement over what we've got; I think that this is something that should not hold back this PR as its a limitation of two other packages.

I have [started on a PR](https://github.com/calebowens/propshaft/tree/fix-relative-imports) for propshaft that will transform all the js `import` and `export` statements to use the digested URLs and hopefully will have it in a PR on Friday