### PR TITLE
bin/importmap verify compares vendored files with remotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,11 +236,12 @@ module MyEngine
 end
 ```
 
-## Checking for outdated or vulnerable packages
+## Checking for outdated, vulnerable or altered packages
 
 Importmap for Rails provides two commands to check your pinned packages:
 - `./bin/importmap outdated` checks the NPM registry for new versions
 - `./bin/importmap audit` checks the NPM registry for known security issues
+- `./bin/importmap verify` checks the vendored files against a fresh download
 
 ## License
 

--- a/test/packager_integration_test.rb
+++ b/test/packager_integration_test.rb
@@ -34,15 +34,25 @@ class Importmap::PackagerIntegrationTest < ActiveSupport::TestCase
       vendored_package_file = Pathname.new(vendor_dir).join("@github--webauthn-json.js")
       assert File.exist?(vendored_package_file)
       assert_equal "// @github/webauthn-json@0.5.7 downloaded from #{package_url}", File.readlines(vendored_package_file).first.strip
+      assert @packager.verify("@github/webauthn-json", package_url)
 
       package_url = "https://ga.jspm.io/npm:react@17.0.2/index.js"
       vendored_package_file = Pathname.new(vendor_dir).join("react.js")
       @packager.download("react", package_url)
       assert File.exist?(vendored_package_file)
       assert_equal "// react@17.0.2 downloaded from #{package_url}", File.readlines(vendored_package_file).first.strip
-      
+      assert @packager.verify("react", package_url)
+
+      File.write(vendored_package_file, "// altered content")
+
+      assert_raises(Importmap::Packager::VerifyError) do
+        @packager.verify("react", package_url)
+      end
+
       @packager.remove("react")
       assert_not File.exist?(Pathname.new(vendor_dir).join("react.js"))
+
+      refute @packager.verify("react", package_url)
     end
   end
 end


### PR DESCRIPTION
In rubygems/rubygems.org#4396 we ran into the problem of verifying the provenance of files in vendor/javascript. This is a blocker for us using importmap-rails at this time.

In this PR, I attempted to add a process that could be run in CI that would download and verify that the files that are vendored are actually what would be downloaded fresh today.

I assume there are some edge-cases, or even really obvious cases, that I didn't handle in this PR. I wanted to start gathering feedback so I know if this is the right solution. 