### PR TITLE
Updated module_name regexp to not match incorrect indexes

### DIFF
--- a/lib/importmap/map.rb
+++ b/lib/importmap/map.rb
@@ -141,7 +141,17 @@ class Importmap::Map
     end
 
     def module_name_from(filename, mapping)
-      [ mapping.under, filename.to_s.remove(filename.extname).remove(/\/?index$/).presence ].compact.join("/")
+      # Regex explanation:
+      # (?:\/|^) # Matches either / OR the start of the string
+      # index   # Matches the word index
+      # $       # Matches the end of the string
+      #
+      # Sample matches
+      # index
+      # folder/index
+      index_regex = /(?:\/|^)index$/
+
+      [ mapping.under, filename.to_s.remove(filename.extname).remove(index_regex).presence ].compact.join("/")
     end
 
     def module_path_from(filename, mapping)

--- a/test/dummy/app/javascript/controllers/special_index.js
+++ b/test/dummy/app/javascript/controllers/special_index.js
@@ -1,0 +1,1 @@
+console.log("Sorry - no imports here!")

--- a/test/dummy/app/javascript/helpers/requests/special_index.js
+++ b/test/dummy/app/javascript/helpers/requests/special_index.js
@@ -1,0 +1,1 @@
+console.log("Sorry, nothing helpful here")

--- a/test/importmap_test.rb
+++ b/test/importmap_test.rb
@@ -44,8 +44,16 @@ class ImportmapTest < ActiveSupport::TestCase
     assert_match %r|assets/controllers/index.*\.js|, generate_importmap_json["imports"]["controllers"]
   end
 
+  test "directory pin mounted under matching subdir doesn't map *_index as root" do
+    assert_match %r|assets/controllers/special_index.*\.js|, generate_importmap_json["imports"]["controllers/special_index"]
+  end
+
   test "directory pin mounted under matching subdir maps index as root at second depth" do
     assert_match %r|assets/helpers/requests/index.*\.js|, generate_importmap_json["imports"]["helpers/requests"]
+  end
+
+  test "directory pin mounted under matching subdir doesn't map *_index as root at second depth" do
+    assert_match %r|assets/helpers/requests/special_index.*\.js|, generate_importmap_json["imports"]["helpers/requests/special_index"]
   end
 
   test "directory pin under custom asset path" do


### PR DESCRIPTION
* Closes https://github.com/rails/importmap-rails/issues/215

This updates the regex used to identify index files to ensure that modules like `foo/special_index` don't get mapped to `foo`.

The cause of the problem was that the previous regex matched 1 or 0 `/` characters, which meant anything followed by `index` and the end of the string, would qualify. We now ensure that we match either the start of the string or `/`