### PR TITLE
Invoke app:template via Rake::Task[].invoke to avoid reloading rakefile

### DIFF
--- a/lib/tasks/importmap_tasks.rake
+++ b/lib/tasks/importmap_tasks.rake
@@ -1,6 +1,9 @@
 namespace :importmap do
   desc "Setup Importmap for the app"
   task :install do
-    system RbConfig.ruby, "./bin/rails", "app:template", "LOCATION=#{File.expand_path("../install/install.rb", __dir__)}"
+    previous_location = ENV["LOCATION"]
+    ENV["LOCATION"] = File.expand_path("../install/install.rb", __dir__)
+    Rake::Task["app:template"].invoke
+    ENV["LOCATION"] = previous_location
   end
 end

--- a/test/installer_test.rb
+++ b/test/installer_test.rb
@@ -31,6 +31,18 @@ class InstallerTest < ActiveSupport::TestCase
     end
   end
 
+  test "doesn't load rakefile twice" do
+    with_new_rails_app do |app_dir|
+      rakefile = File.read("#{app_dir}/Rakefile")
+      rakefile = "puts \"I've been logged twice!\" \n" + rakefile
+      File.write("#{app_dir}/Rakefile", rakefile)
+
+      out, err = run_command("bin/rails", "importmap:install")
+
+      assert_equal 1, out.scan(/I've been logged twice!/).size
+    end
+  end
+
   private
     def with_new_rails_app
       # Unset testing dummy app so app generator doesn't get confused in Rails 6.1 and 7.0.
@@ -54,7 +66,7 @@ class InstallerTest < ActiveSupport::TestCase
 
           run_command("bundle", "install")
 
-          yield
+          yield(app_dir)
         end
       end
     end


### PR DESCRIPTION
* Closes https://github.com/rails/importmap-rails/issues/204

This commit moves from using the `system` function which invokes the Rakefile twice and moves to use `Rake::Task[].invoke` which similarly calls `app:template` but doesn't reload the Rakefile