### PR TITLE
Allow multiple importmaps in config/importmaps/

### DIFF
--- a/app/helpers/importmap/importmap_tags_helper.rb
+++ b/app/helpers/importmap/importmap_tags_helper.rb
@@ -8,7 +8,7 @@ module Importmap::ImportmapTagsHelper
     end
 
     safe_join [
-      javascript_inline_importmap_tag(importmap.to_json(resolver: self)),
+      javascript_inline_importmap_tag(importmap),
       javascript_importmap_module_preload_tags(importmap),
       javascript_import_module_tag(entry_point)
     ], "\n"
@@ -16,7 +16,8 @@ module Importmap::ImportmapTagsHelper
 
   # Generate an inline importmap tag using the passed `importmap_json` JSON string.
   # By default, `Rails.application.importmap.to_json(resolver: self)` is used.
-  def javascript_inline_importmap_tag(importmap_json)
+  def javascript_inline_importmap_tag(importmap)
+    importmap_json = importmap.to_json(resolver: self)
     tag.script importmap_json.html_safe,
       type: "importmap", "data-turbo-track": "reload", nonce: request&.content_security_policy_nonce
   end

--- a/app/helpers/importmap/importmap_tags_helper.rb
+++ b/app/helpers/importmap/importmap_tags_helper.rb
@@ -1,22 +1,17 @@
 module Importmap::ImportmapTagsHelper
   # Setup all script tags needed to use an importmap-powered entrypoint (which defaults to application.js)
-  def javascript_importmap_tags(entry_point = "application")
-    importmap = Rails.application.importmaps.fetch(entry_point.to_s)
-
-    unless importmap
-      raise "No importmap found for entry point '#{entry_point}'."
-    end
-
+  def javascript_importmap_tags(entry_point = "application", importmap_name = "application")
     safe_join [
-      javascript_inline_importmap_tag(importmap),
-      javascript_importmap_module_preload_tags(importmap),
+      javascript_inline_importmap_tag(importmap_name),
+      javascript_importmap_module_preload_tags(importmap_name),
       javascript_import_module_tag(entry_point)
     ], "\n"
   end
 
   # Generate an inline importmap tag using the passed `importmap_json` JSON string.
   # By default, `Rails.application.importmap.to_json(resolver: self)` is used.
-  def javascript_inline_importmap_tag(importmap)
+  def javascript_inline_importmap_tag(importmap_name = "application")
+    importmap = Rails.application.importmaps.fetch(importmap_name.to_s)
     importmap_json = importmap.to_json(resolver: self)
     tag.script importmap_json.html_safe,
       type: "importmap", "data-turbo-track": "reload", nonce: request&.content_security_policy_nonce
@@ -31,7 +26,8 @@ module Importmap::ImportmapTagsHelper
   # Link tags for preloading all modules marked as preload: true in the `importmap`
   # (defaults to Rails.application.importmap), such that they'll be fetched
   # in advance by browsers supporting this link type (https://caniuse.com/?search=modulepreload).
-  def javascript_importmap_module_preload_tags(importmap)
+  def javascript_importmap_module_preload_tags(importmap_name = "application")
+    importmap = Rails.application.importmaps.fetch(importmap_name.to_s)
     javascript_module_preload_tag(*importmap.preloaded_module_paths(resolver: self))
   end
 

--- a/app/helpers/importmap/importmap_tags_helper.rb
+++ b/app/helpers/importmap/importmap_tags_helper.rb
@@ -1,13 +1,11 @@
 module Importmap::ImportmapTagsHelper
   # Setup all script tags needed to use an importmap-powered entrypoint (which defaults to application.js)
   def javascript_importmap_tags(entry_point = "application")
-    entry_point = entry_point.to_s
+    importmap = Rails.application.importmaps.fetch(entry_point.to_s)
 
-    importmap_identifier =
-      entry_point != "application" && Rails.application.importmaps.key?(entry_point) ?
-      entry_point :
-      "application"
-    importmap = Rails.application.importmaps.fetch(entry_point)
+    unless importmap
+      raise "No importmap found for entry point '#{entry_point}'."
+    end
 
     safe_join [
       javascript_inline_importmap_tag(importmap.to_json(resolver: self)),

--- a/app/helpers/importmap/importmap_tags_helper.rb
+++ b/app/helpers/importmap/importmap_tags_helper.rb
@@ -1,6 +1,14 @@
 module Importmap::ImportmapTagsHelper
   # Setup all script tags needed to use an importmap-powered entrypoint (which defaults to application.js)
-  def javascript_importmap_tags(entry_point = "application", importmap: Rails.application.importmap)
+  def javascript_importmap_tags(entry_point = "application")
+    entry_point = entry_point.to_s
+
+    importmap_identifier =
+      entry_point != "application" && Rails.application.importmaps.key?(entry_point) ?
+      entry_point :
+      "application"
+    importmap = Rails.application.importmaps.fetch(entry_point)
+
     safe_join [
       javascript_inline_importmap_tag(importmap.to_json(resolver: self)),
       javascript_importmap_module_preload_tags(importmap),
@@ -10,7 +18,7 @@ module Importmap::ImportmapTagsHelper
 
   # Generate an inline importmap tag using the passed `importmap_json` JSON string.
   # By default, `Rails.application.importmap.to_json(resolver: self)` is used.
-  def javascript_inline_importmap_tag(importmap_json = Rails.application.importmap.to_json(resolver: self))
+  def javascript_inline_importmap_tag(importmap_json)
     tag.script importmap_json.html_safe,
       type: "importmap", "data-turbo-track": "reload", nonce: request&.content_security_policy_nonce
   end
@@ -24,7 +32,7 @@ module Importmap::ImportmapTagsHelper
   # Link tags for preloading all modules marked as preload: true in the `importmap`
   # (defaults to Rails.application.importmap), such that they'll be fetched
   # in advance by browsers supporting this link type (https://caniuse.com/?search=modulepreload).
-  def javascript_importmap_module_preload_tags(importmap = Rails.application.importmap)
+  def javascript_importmap_module_preload_tags(importmap)
     javascript_module_preload_tag(*importmap.preloaded_module_paths(resolver: self))
   end
 

--- a/gemfiles/rails_main_propshaft.gemfile
+++ b/gemfiles/rails_main_propshaft.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", branch: "main", git: "https://github.com/rails/rails.git"
-gem "sqlite3", "~> 1.4"
+gem "sqlite3", "~> 2.0"
 gem "propshaft"
 
 group :development do

--- a/gemfiles/rails_main_sprockets.gemfile
+++ b/gemfiles/rails_main_sprockets.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", branch: "main", git: "https://github.com/rails/rails.git"
-gem "sqlite3", "~> 1.4"
+gem "sqlite3", "~> 2.0"
 gem "sprockets-rails"
 
 group :development do

--- a/lib/importmap/packager.rb
+++ b/lib/importmap/packager.rb
@@ -10,10 +10,11 @@ class Importmap::Packager
   singleton_class.attr_accessor :endpoint
   self.endpoint = URI("https://api.jspm.io/generate")
 
+  attr_reader :importmap_path
   attr_reader :vendor_path
 
-  def initialize(importmap_path = "config/importmap.rb", vendor_path: "vendor/javascript")
-    @importmap_path = Pathname.new(importmap_path)
+  def initialize(importmap_name = "application", vendor_path: "vendor/javascript")
+    @importmap_path = Pathname.new(importmap_name == "application" ? "config/importmap.rb" : "config/importmaps/#{importmap_name}.rb")
     @vendor_path    = Pathname.new(vendor_path)
   end
 

--- a/lib/importmap/reloader.rb
+++ b/lib/importmap/reloader.rb
@@ -5,7 +5,9 @@ class Importmap::Reloader
   delegate :execute_if_updated, :execute, :updated?, to: :updater
 
   def reload!
-    import_map_paths.each { |path| Rails.application.importmap.draw(path) }
+    Rails.application.importmaps.values.each do |importmap|
+      import_map_paths.each { |path| importmap.draw(path) }
+    end
   end
 
   private

--- a/test/importmap_tags_helper_test.rb
+++ b/test/importmap_tags_helper_test.rb
@@ -50,10 +50,12 @@ class Importmap::ImportmapTagsHelperTest < ActionView::TestCase
   end
 
   test "using a custom importmap" do
-    importmap = Importmap::Map.new
-    importmap.pin "foo", preload: true
-    importmap.pin "bar", preload: false
-    importmap_html = javascript_importmap_tags("foo", importmap: importmap)
+    Rails.application.importmaps["custom"] = Importmap::Map.new.tap do |importmap|
+      importmap.pin "foo", preload: true
+      importmap.pin "bar", preload: false
+    end
+
+    importmap_html = javascript_importmap_tags("foo", "custom")
 
     assert_includes importmap_html, %{<script type="importmap" data-turbo-track="reload">}
     assert_includes importmap_html, %{"foo": "/foo.js"}

--- a/test/packager_integration_test.rb
+++ b/test/packager_integration_test.rb
@@ -2,7 +2,10 @@ require "test_helper"
 require "importmap/packager"
 
 class Importmap::PackagerIntegrationTest < ActiveSupport::TestCase
-  setup { @packager = Importmap::Packager.new(Rails.root.join("config/importmap.rb")) }
+  setup do
+    Dir.chdir(Rails.root)
+    @packager = Importmap::Packager.new
+  end
 
   test "successful import against live service" do
     assert_equal "https://ga.jspm.io/npm:react@17.0.2/index.js", @packager.import("react@17.0.2")["react"]
@@ -26,7 +29,7 @@ class Importmap::PackagerIntegrationTest < ActiveSupport::TestCase
   test "successful downloads from live service" do
     Dir.mktmpdir do |vendor_dir|
       @packager = Importmap::Packager.new \
-        Rails.root.join("config/importmap.rb"),
+        "application",
         vendor_path: Pathname.new(vendor_dir)
 
       package_url = "https://ga.jspm.io/npm:@github/webauthn-json@0.5.7/dist/main/webauthn-json.js"
@@ -40,7 +43,7 @@ class Importmap::PackagerIntegrationTest < ActiveSupport::TestCase
       @packager.download("react", package_url)
       assert File.exist?(vendored_package_file)
       assert_equal "// react@17.0.2 downloaded from #{package_url}", File.readlines(vendored_package_file).first.strip
-      
+
       @packager.remove("react")
       assert_not File.exist?(Pathname.new(vendor_dir).join("react.js"))
     end

--- a/test/packager_single_quotes_test.rb
+++ b/test/packager_single_quotes_test.rb
@@ -3,9 +3,11 @@ require "importmap/packager"
 
 class Importmap::PackagerSingleQuotesTest < ActiveSupport::TestCase
   setup do
-    @single_quote_config_name = Rails.root.join("config/importmap_with_single_quotes.rb")
+    @single_quote_config_name = Rails.root.join("config/importmaps/single_quotes.rb")
+    FileUtils.mkdir_p @single_quote_config_name.dirname
     File.write(@single_quote_config_name, File.read(Rails.root.join("config/importmap.rb")).tr('"', "'"))
-    @packager = Importmap::Packager.new(@single_quote_config_name)
+    Dir.chdir(Rails.root)
+    @packager = Importmap::Packager.new("single_quotes")
   end
 
   teardown { File.delete(@single_quote_config_name) }

--- a/test/packager_test.rb
+++ b/test/packager_test.rb
@@ -3,7 +3,10 @@ require "importmap/packager"
 require "minitest/mock"
 
 class Importmap::PackagerTest < ActiveSupport::TestCase
-  setup { @packager = Importmap::Packager.new(Rails.root.join("config/importmap.rb")) }
+  setup do
+    Dir.chdir(Rails.root)
+    @packager = Importmap::Packager.new
+  end
 
   test "successful import with mock" do
     response = Class.new do

--- a/test/reloader_test.rb
+++ b/test/reloader_test.rb
@@ -13,10 +13,10 @@ class ReloaderTest < ActiveSupport::TestCase
   end
 
   test "redraws importmap when config changes" do
-    Rails.application.importmap = Importmap::Map.new.draw { pin "md5", to: "https://cdn.skypack.dev/md5" }
+    Rails.application.importmaps["application"] = Importmap::Map.new.draw { pin "md5", to: "https://cdn.skypack.dev/md5" }
     assert_not_predicate @reloader, :updated?
 
-    assert_changes -> { Rails.application.importmap.packages.keys }, from: %w[ md5 ], to: %w[ md5 not_there ] do
+    assert_changes -> { Rails.application.importmaps["application"].packages.keys }, from: %w[ md5 ], to: %w[ md5 not_there ] do
       touch_config
       assert @reloader.execute_if_updated
     end


### PR DESCRIPTION
I implemented the idea mentioned in #240 of allowing multiple importmaps.
It was pretty straightforward and so far works great (for my use-case).

Instead of having one `Importmap::Map` in `Rails.application.importmap`, we now have `Rails.application.importmaps` (plural) that is a hash in the form of:

```ruby
{
  "application" => #<Importmap::Map>,
  "web" => #<Importmap::Map>,
  "admin" => #<Importmap::Map>,
  "clients" => #<Importmap::Map>
}
```

`config/importmap.rb` is now the "application" importmap (which should contain all packages that are needed in all namespaces), `config/importmaps/web.rb` defines the packages for the "web" namespace, and so forth.

In my app, I can then simply call `javascript_importmap_tags :web` and it will include the "web" entry point and the correct importmap.

Looking forward to feedback! 😄 
And of course happy to work more on the implementation, add tests, etc.