### PR TITLE
Handle String response for "find latest version"

### DIFF
--- a/lib/importmap/npm.rb
+++ b/lib/importmap/npm.rb
@@ -86,7 +86,7 @@ class Importmap::Npm
     end
 
     def find_latest_version(response)
-      latest_version = response.dig('dist-tags', 'latest')
+      latest_version = response.is_a?(String) ? response : response.dig('dist-tags', 'latest')
       return latest_version if latest_version
 
       return unless response['versions']

--- a/test/npm_test.rb
+++ b/test/npm_test.rb
@@ -94,4 +94,17 @@ class Importmap::NpmTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test "return response is a String type" do
+    response = "version not found".to_json
+
+    @npm.stub(:get_json, response) do
+      outdated_packages = @npm.outdated_packages
+
+      assert_equal(1, outdated_packages.size)
+      assert_equal('md5', outdated_packages[0].name)
+      assert_equal('2.2.0', outdated_packages[0].current_version)
+      assert_equal('version not found', outdated_packages[0].latest_version)
+    end
+  end
 end

--- a/test/npm_test.rb
+++ b/test/npm_test.rb
@@ -101,9 +101,6 @@ class Importmap::NpmTest < ActiveSupport::TestCase
     @npm.stub(:get_json, response) do
       outdated_packages = @npm.outdated_packages
 
-      assert_equal(1, outdated_packages.size)
-      assert_equal('md5', outdated_packages[0].name)
-      assert_equal('2.2.0', outdated_packages[0].current_version)
       assert_equal('version not found', outdated_packages[0].latest_version)
     end
   end

--- a/test/npm_test.rb
+++ b/test/npm_test.rb
@@ -95,7 +95,7 @@ class Importmap::NpmTest < ActiveSupport::TestCase
     end
   end
 
-  test "return response is a String type" do
+  test "return latest version response is a String type" do
     response = "version not found".to_json
 
     @npm.stub(:get_json, response) do


### PR DESCRIPTION
Closes https://github.com/rails/importmap-rails/issues/245

# Problem

It is expected NPM to return a Hash for the response.

https://github.com/rails/importmap-rails/blob/ddf9be434e0aca1103eabafe6d34b0e8a5064057/lib/importmap/npm.rb#L89

But for whatever reason the response can now also return a String, which is not accounted for in `npm.rb`.

See the referenced issue for further context.

# Expectation

The `importmap outdated` command should handle the problem more gracefully. In this case, a reasonable expectation is to surface the String response.

# Solution

How to handle is up for discussion.

Just to get the fix process started the propose change is to surface the String in the response as `latest_version` since it isn't clear what the contents of the String could be.

Using the fork with change on our production app which has the problematic pinned dependency, the following `outdated` is now returned.

```
| Package                | Current | Latest                 |
|------------------------|---------|------------------------|
| @floating-ui/utils/dom | 0.2.1   | version not found: dom |
  1 outdated package found
```