### PR TITLE
Allows preload to be determined by provided entry_point

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,25 @@ pin "md5", preload: false # file lives in vendor/javascript/md5.js
 ...
 ```
 
+You can also specify which entry points to preload a particular dependency in by providing `preload:` a string or array of strings.
+
+Example:
+
+```ruby
+# config/importmap.rb
+pin "@github/hotkey", to: "@github--hotkey.js", preload: 'application'
+pin "md5", preload: ['application', 'alternate']
+
+# app/views/layouts/application.html.erb
+<%= javascript_importmap_tags 'alternate' %>
+
+# will include the following link before the importmap is setup:
+<link rel="modulepreload" href="/assets/javascript/md5.js">
+...
+```
+
+
+
 ## Composing import maps
 
 By default, Rails loads import map definition from the application's `config/importmap.rb` to the `Importmap::Map` object available at `Rails.application.importmap`.

--- a/app/helpers/importmap/importmap_tags_helper.rb
+++ b/app/helpers/importmap/importmap_tags_helper.rb
@@ -24,7 +24,7 @@ module Importmap::ImportmapTagsHelper
   # Link tags for preloading all modules marked as preload: true in the `importmap`
   # (defaults to Rails.application.importmap), such that they'll be fetched
   # in advance by browsers supporting this link type (https://caniuse.com/?search=modulepreload).
-  def javascript_importmap_module_preload_tags(importmap = Rails.application.importmap, entry_point:)
+  def javascript_importmap_module_preload_tags(importmap = Rails.application.importmap, entry_point: "application")
     javascript_module_preload_tag(*importmap.preloaded_module_paths(resolver: self, entry_point:))
   end
 

--- a/app/helpers/importmap/importmap_tags_helper.rb
+++ b/app/helpers/importmap/importmap_tags_helper.rb
@@ -3,7 +3,7 @@ module Importmap::ImportmapTagsHelper
   def javascript_importmap_tags(entry_point = "application", importmap: Rails.application.importmap)
     safe_join [
       javascript_inline_importmap_tag(importmap.to_json(resolver: self)),
-      javascript_importmap_module_preload_tags(importmap),
+      javascript_importmap_module_preload_tags(importmap, entry_point:),
       javascript_import_module_tag(entry_point)
     ], "\n"
   end
@@ -24,8 +24,8 @@ module Importmap::ImportmapTagsHelper
   # Link tags for preloading all modules marked as preload: true in the `importmap`
   # (defaults to Rails.application.importmap), such that they'll be fetched
   # in advance by browsers supporting this link type (https://caniuse.com/?search=modulepreload).
-  def javascript_importmap_module_preload_tags(importmap = Rails.application.importmap)
-    javascript_module_preload_tag(*importmap.preloaded_module_paths(resolver: self))
+  def javascript_importmap_module_preload_tags(importmap = Rails.application.importmap, entry_point:)
+    javascript_module_preload_tag(*importmap.preloaded_module_paths(resolver: self, entry_point:))
   end
 
   # Link tag(s) for preloading the JavaScript module residing in `*paths`. Will return one link tag per path element.

--- a/lib/importmap/map.rb
+++ b/lib/importmap/map.rb
@@ -40,9 +40,9 @@ class Importmap::Map
   # resolver that has been configured for the `asset_host` you want these resolved paths to use. In case you need to
   # resolve for different asset hosts, you can pass in a custom `cache_key` to vary the cache used by this method for
   # the different cases.
-  def preloaded_module_paths(resolver:, cache_key: :preloaded_module_paths)
+  def preloaded_module_paths(resolver:, entry_point:, cache_key: :preloaded_module_paths)
     cache_as(cache_key) do
-      resolve_asset_paths(expanded_preloading_packages_and_directories, resolver: resolver).values
+      resolve_asset_paths(expanded_preloading_packages_and_directories(entry_point:), resolver:).values
     end
   end
 
@@ -118,8 +118,8 @@ class Importmap::Map
       end.compact
     end
 
-    def expanded_preloading_packages_and_directories
-      expanded_packages_and_directories.select { |name, mapping| mapping.preload }
+    def expanded_preloading_packages_and_directories(entry_point:)
+      expanded_packages_and_directories.select { |name, mapping| mapping.preload == true || (mapping.preload & Array(entry_point)).any? }
     end
 
     def expanded_packages_and_directories

--- a/lib/importmap/map.rb
+++ b/lib/importmap/map.rb
@@ -40,7 +40,7 @@ class Importmap::Map
   # resolver that has been configured for the `asset_host` you want these resolved paths to use. In case you need to
   # resolve for different asset hosts, you can pass in a custom `cache_key` to vary the cache used by this method for
   # the different cases.
-  def preloaded_module_paths(resolver:, entry_point:, cache_key: :preloaded_module_paths)
+  def preloaded_module_paths(resolver:, entry_point: "application", cache_key: :preloaded_module_paths)
     cache_as(cache_key) do
       resolve_asset_paths(expanded_preloading_packages_and_directories(entry_point:), resolver:).values
     end
@@ -119,7 +119,7 @@ class Importmap::Map
     end
 
     def expanded_preloading_packages_and_directories(entry_point:)
-      expanded_packages_and_directories.select { |name, mapping| mapping.preload == true || (mapping.preload & Array(entry_point)).any? }
+      expanded_packages_and_directories.select { |name, mapping| mapping.preload.in?([true, false]) ? mapping.preload : (Array(mapping.preload) & Array(entry_point)).any? }
     end
 
     def expanded_packages_and_directories


### PR DESCRIPTION
As discussed in https://github.com/rails/importmap-rails/issues/240#issuecomment-1998340405, this PR allows preload to accept 1+ strings representing entry_points instead of just a boolean for the value of a mapping's preload. That way you can forgo creating multiple importmaps and instead use an application-wide importmap and modify what is preloaded based on where you are.