### PR TITLE
make multiline importmap definitions work with `importmap outdated` for instance

### DIFF
--- a/lib/importmap/npm.rb
+++ b/lib/importmap/npm.rb
@@ -48,8 +48,8 @@ class Importmap::Npm
     # We cannot use the name after "pin" because some dependencies are loaded from inside packages
     # Eg. pin "buffer", to: "https://ga.jspm.io/npm:@jspm/core@2.0.0-beta.19/nodelibs/browser/buffer.js"
 
-    importmap.scan(/^pin .*(?<=npm:|npm\/|skypack\.dev\/|unpkg\.com\/)(.*)(?=@\d+\.\d+\.\d+)@(\d+\.\d+\.\d+(?:[^\/\s["']]*)).*$/) |
-      importmap.scan(/^pin ["']([^["']]*)["'].* #.*@(\d+\.\d+\.\d+(?:[^\s]*)).*$/)
+    importmap.scan(/pin .*(?<=npm:|npm\/|skypack\.dev\/|unpkg\.com\/)(.*)(?=@\d+\.\d+\.\d+)@(\d+\.\d+\.\d+(?:[^\/\s["']]*)).*/m) |
+      importmap.scan(/pin ["']([^["']]*)["'].* #.*@(\d+\.\d+\.\d+(?:[^\s]*)).*/m)
   end
 
   private

--- a/test/fixtures/files/multiline_outdated_import_map.rb
+++ b/test/fixtures/files/multiline_outdated_import_map.rb
@@ -1,2 +1,2 @@
 ipin "intl-tel-input/build/js/utils.js",
-     to: "intl-tel-input--build--js--utils.js.js" # @23.5.0
+     to: "intl-tel-input--build--js--utils.js.js" # @23.3.2

--- a/test/fixtures/files/multiline_outdated_import_map.rb
+++ b/test/fixtures/files/multiline_outdated_import_map.rb
@@ -1,0 +1,2 @@
+ipin "intl-tel-input/build/js/utils.js",
+     to: "intl-tel-input--build--js--utils.js.js" # @23.5.0

--- a/test/fixtures/files/multiline_updated_import_map.rb
+++ b/test/fixtures/files/multiline_updated_import_map.rb
@@ -1,2 +1,2 @@
 ipin "intl-tel-input/build/js/utils.js",
-    to: "intl-tel-input--build--js--utils.js.js" # @23.3.2
+    to: "intl-tel-input--build--js--utils.js.js" # @23.5.0

--- a/test/fixtures/files/multiline_updated_import_map.rb
+++ b/test/fixtures/files/multiline_updated_import_map.rb
@@ -1,0 +1,2 @@
+ipin "intl-tel-input/build/js/utils.js",
+    to: "intl-tel-input--build--js--utils.js.js" # @23.3.2

--- a/test/npm_test.rb
+++ b/test/npm_test.rb
@@ -46,6 +46,30 @@ class Importmap::NpmTest < ActiveSupport::TestCase
     end
   end
 
+  test "successful outdated packages using multiple lines" do
+    npm = Importmap::Npm.new(file_fixture("multiline_outdated_import_map.rb"))
+    response = { "dist-tags" => { "latest" => '23.5.0' } }.to_json
+
+    npm.stub(:get_json, response) do
+      outdated_packages = npm.outdated_packages
+
+      assert_equal(1, outdated_packages.size)
+      assert_equal('intl-tel-input/build/js/utils.js', outdated_packages[0].name)
+      assert_equal('23.3.2', outdated_packages[0].current_version)
+      assert_equal('23.5.0', outdated_packages[0].latest_version)
+    end
+  end
+
+  test "successful updarted packages using multiple lines" do
+    npm = Importmap::Npm.new(file_fixture("multiline_updated_import_map.rb"))
+    response = { "dist-tags" => { "latest" => '23.5.0' } }.to_json
+
+    npm.stub(:get_json, response) do
+      outdated_packages = npm.outdated_packages
+      assert_equal(0, outdated_packages.size)
+    end
+  end
+
   test "missing outdated packages with mock" do
     response = { "error" => "Not found" }.to_json
 


### PR DESCRIPTION
i had a package that kept being marked as outdated and thus my ci was failing