### PR TITLE
Fix ./bin/importmap update

### DIFF
--- a/lib/importmap/commands.rb
+++ b/lib/importmap/commands.rb
@@ -92,7 +92,7 @@ class Importmap::Commands < Thor
   desc "update", "Update outdated package pins"
   def update
     if (outdated_packages = npm.outdated_packages).any?
-      pin outdated_packages.map(&:name)
+      pin(*outdated_packages.map(&:name))
     else
       puts "No outdated packages found"
     end

--- a/test/commands_test.rb
+++ b/test/commands_test.rb
@@ -20,6 +20,22 @@ class CommandsTest < ActiveSupport::TestCase
     assert_includes JSON.parse(out), "imports"
   end
 
+  test "update command prints message of no outdated packages" do
+    out, _err = run_importmap_command("update")
+    assert_includes out, "No outdated"
+  end
+
+  test "update command prints confirmation of pin with outdated packages" do
+    @tmpdir = Dir.mktmpdir
+    FileUtils.cp_r("#{__dir__}/dummy", @tmpdir)
+    Dir.chdir("#{@tmpdir}/dummy")
+    FileUtils.cp("#{__dir__}/fixtures/files/outdated_import_map.rb", "#{@tmpdir}/dummy/config/importmap.rb")
+    FileUtils.cp("#{__dir__}/../lib/install/bin/importmap", "bin")
+
+    out, _err = run_importmap_command("update")
+    assert_includes out, "Pinning"
+  end
+
   private
     def run_importmap_command(command, *args)
       capture_subprocess_io { system("bin/importmap", command, *args, exception: true) }


### PR DESCRIPTION
This aims to fix #228

Also adds tests for the `./bin/importmap update` command.

I tried to investigate when this stopped working but could not pinpoint it. Tried various older Ruby versions and older Importmap versions but did not find anything.