### PR TITLE
Use entry_point as cache_key when generating preload tags

### DIFF
--- a/app/helpers/importmap/importmap_tags_helper.rb
+++ b/app/helpers/importmap/importmap_tags_helper.rb
@@ -25,7 +25,7 @@ module Importmap::ImportmapTagsHelper
   # (defaults to Rails.application.importmap), such that they'll be fetched
   # in advance by browsers supporting this link type (https://caniuse.com/?search=modulepreload).
   def javascript_importmap_module_preload_tags(importmap = Rails.application.importmap, entry_point: "application")
-    javascript_module_preload_tag(*importmap.preloaded_module_paths(resolver: self, entry_point:))
+    javascript_module_preload_tag(*importmap.preloaded_module_paths(resolver: self, entry_point:, cache_key: entry_point))
   end
 
   # Link tag(s) for preloading the JavaScript module residing in `*paths`. Will return one link tag per path element.


### PR DESCRIPTION
Determining preload by provided entry_point (See #253) can result in a cached version of the preload tags to be rendered, based on another entry_point. To prevent that, use the provided entry_point as the cache key.
