### PR TITLE
Fix syntax error in importmap-rails 2.0.2 (unexpected ')')

### DIFF
--- a/lib/importmap/map.rb
+++ b/lib/importmap/map.rb
@@ -42,7 +42,7 @@ class Importmap::Map
   # the different cases.
   def preloaded_module_paths(resolver:, entry_point: "application", cache_key: :preloaded_module_paths)
     cache_as(cache_key) do
-      resolve_asset_paths(expanded_preloading_packages_and_directories(entry_point:), resolver:).values
+      resolve_asset_paths(expanded_preloading_packages_and_directories(entry_point: entry_point), resolver:).values
     end
   end
 


### PR DESCRIPTION
## Description
This pull request fixes a syntax error in importmap-rails version 2.0.2 that caused the following error during application boot:
```
/usr/local/bundle/gems/importmap-rails-2.0.2/lib/importmap/map.rb:45: syntax error, unexpected ')'
...s_and_directories(entry_point:), resolver:).values
...                              ^
```

The issue was related to incorrect usage of parentheses in the map.rb file, which was preventing the application from starting properly. The parentheses have been corrected to resolve this error.

## Changes

Corrected syntax in importmap/map.rb to fix the parentheses error.
Why this change is necessary: This bug prevented the application from starting, impacting users who rely on importmap-rails version 2.0.2. This fix ensures the application can boot without syntax errors.

