### PR TITLE
Adds `bin/importmap pristine` which redownloads pinned packages

### DIFF
--- a/lib/importmap/commands.rb
+++ b/lib/importmap/commands.rb
@@ -46,6 +46,24 @@ class Importmap::Commands < Thor
     end
   end
 
+  desc "pristine [*PACKAGES]", "Redownload all pinned packages"
+  option :env, type: :string, aliases: :e, default: "production"
+  option :from, type: :string, aliases: :f, default: "jspm"
+  def pristine(*packages)
+    packages = npm.packages_with_versions.map do |p, v|
+      v.blank? ? p : [p, v].join("@")
+    end
+
+    if imports = packager.import(*packages, env: options[:env], from: options[:from])
+      imports.each do |package, url|
+        puts %(Downloading "#{package}" to #{packager.vendor_path}/#{package}.js from #{url})
+        packager.download(package, url)
+      end
+    else
+      puts "Couldn't find any packages in #{packages.inspect} on #{options[:from]}"
+    end
+  end
+
   desc "json", "Show the full importmap in json"
   def json
     require Rails.root.join("config/environment")

--- a/test/commands_test.rb
+++ b/test/commands_test.rb
@@ -36,6 +36,25 @@ class CommandsTest < ActiveSupport::TestCase
     assert_includes out, "Pinning"
   end
 
+  test "pristine command redownloads all pinned packages" do
+    @tmpdir = Dir.mktmpdir
+    FileUtils.cp_r("#{__dir__}/dummy", @tmpdir)
+    Dir.chdir("#{@tmpdir}/dummy")
+    FileUtils.cp("#{__dir__}/fixtures/files/outdated_import_map.rb", "#{@tmpdir}/dummy/config/importmap.rb")
+    FileUtils.cp("#{__dir__}/../lib/install/bin/importmap", "bin")
+    out, _err = run_importmap_command("pin", "md5@2.2.0")
+
+    assert_includes out, 'Pinning "md5" to vendor/javascript/md5.js via download from https://ga.jspm.io/npm:md5@2.2.0/md5.js'
+
+    original = File.read("#{@tmpdir}/dummy/vendor/javascript/md5.js")
+    File.write("#{@tmpdir}/dummy/vendor/javascript/md5.js", "corrupted")
+
+    out, _err = run_importmap_command("pristine")
+
+    assert_includes out, 'Downloading "md5" to vendor/javascript/md5.js from https://ga.jspm.io/npm:md5@2.2.0'
+    assert_equal original, File.read("#{@tmpdir}/dummy/vendor/javascript/md5.js")
+  end
+
   private
     def run_importmap_command(command, *args)
       capture_subprocess_io { system("bin/importmap", command, *args, exception: true) }


### PR DESCRIPTION
I was trying to keep #237 working on RubyGems.org and ran into the problem of the new comments being added to the file. This command redownloads files without changing which version is used.

This is a substitute for manually running `bin/importmap pin pkg@1.2.3` for each package.