### PR TITLE
Correct pristine command description and args

### DIFF
--- a/lib/importmap/commands.rb
+++ b/lib/importmap/commands.rb
@@ -46,10 +46,10 @@ class Importmap::Commands < Thor
     end
   end
 
-  desc "pristine [*PACKAGES]", "Redownload all pinned packages"
+  desc "pristine", "Redownload all pinned packages"
   option :env, type: :string, aliases: :e, default: "production"
   option :from, type: :string, aliases: :f, default: "jspm"
-  def pristine(*packages)
+  def pristine
     packages = npm.packages_with_versions.map do |p, v|
       v.blank? ? p : [p, v].join("@")
     end


### PR DESCRIPTION
In #271 I made the mistake of leaving `*packages` in the args. They are ignored, so remove them.

cc: @dhh 