### PR TITLE
Carry over pin options when pinning an existing pin

### DIFF
--- a/lib/importmap/packager.rb
+++ b/lib/importmap/packager.rb
@@ -39,12 +39,14 @@ class Importmap::Packager
   def vendored_pin_for(package, url)
     filename = package_filename(package)
     version  = extract_package_version_from(url)
+    line_formatted_pin_options = pin_options_for_package(package).except("to").map { |option, value| %(#{option}: #{value.is_a?(String) ? %("#{value}") : value}) }
+    pin_components = [
+      %(pin "#{package}"),
+      (%(to: "#{filename}") unless "#{package}.js" == filename),
+      *line_formatted_pin_options
+    ].compact
 
-    if "#{package}.js" == filename
-      %(pin "#{package}" # #{version})
-    else
-      %(pin "#{package}", to: "#{filename}" # #{version})
-    end
+    %(#{pin_components.join(", ")} # #{version})
   end
 
   def packaged?(package)

--- a/lib/importmap/packager.rb
+++ b/lib/importmap/packager.rb
@@ -39,12 +39,11 @@ class Importmap::Packager
   def vendored_pin_for(package, url)
     filename = package_filename(package)
     version  = extract_package_version_from(url)
-    line_formatted_pin_options = pin_options_for_package(package).except("to").map { |option, value| %(#{option}: #{value.is_a?(String) ? %("#{value}") : value}) }
-    pin_components = [
-      %(pin "#{package}"),
-      (%(to: "#{filename}") unless "#{package}.js" == filename),
-      *line_formatted_pin_options
-    ].compact
+    line_formatted_pin_options =
+      pin_options_for_package(package).
+        tap { |options| "#{package}.js" == filename ? options.delete("to") : options["to"] = filename }.
+        map { |option, value| %(#{option}: #{value.is_a?(String) ? %("#{value}") : value}) }
+    pin_components = [%(pin "#{package}"), *line_formatted_pin_options]
 
     %(#{pin_components.join(", ")} # #{version})
   end

--- a/lib/importmap/packager.rb
+++ b/lib/importmap/packager.rb
@@ -70,7 +70,7 @@ class Importmap::Packager
 
     return {} if raw_options.blank?
 
-    raw_options[:pin_options].split(/,\s|,/).each_with_object({}) do |option, hash|
+    raw_options[:pin_options].split(/,\s?/).each_with_object({}) do |option, hash|
       match_data = option.match(/^(?<option_name>[^:]*):[\s+]?["']?(?<option_value>.*[^"'])["']?$/)
 
       hash[match_data[:option_name]] = cast_option_value(match_data[:option_value])

--- a/lib/importmap/packager.rb
+++ b/lib/importmap/packager.rb
@@ -70,9 +70,7 @@ class Importmap::Packager
 
     return {} if raw_options.blank?
 
-    normalized_delimiter_raw_options = raw_options[:pin_options].gsub(/,\s/, ',').split(',')
-
-    normalized_delimiter_raw_options.each_with_object({}) do |option, hash|
+    raw_options[:pin_options].split(/,\s|,/).each_with_object({}) do |option, hash|
       match_data = option.match(/^(?<option_name>[^:]*):[\s+]?["']?(?<option_value>.*[^"'])["']?$/)
 
       hash[match_data[:option_name]] = cast_option_value(match_data[:option_value])

--- a/lib/importmap/packager.rb
+++ b/lib/importmap/packager.rb
@@ -48,7 +48,7 @@ class Importmap::Packager
   end
 
   def packaged?(package)
-    importmap.match(/^pin ["']#{package}["'].*$/)
+    importmap.match(/^pin ["']#{package}["'].*$/).present?
   end
 
   def download(package, url)

--- a/test/fixtures/files/pins_with_various_options_importmap.rb
+++ b/test/fixtures/files/pins_with_various_options_importmap.rb
@@ -5,3 +5,4 @@ pin "not_there", to: "nowhere.js", preload: false # 1.9.1
 pin "some_file" # 0.2.1
 pin "another_file",to:'another_file.js' # @0.0.16
 pin "random", random_option: "foobar", hello: "world" # 7.7.7
+pin "javascript/typescript", preload: true, to: "https://cdn.skypack.dev/typescript" # 0.0.0

--- a/test/fixtures/files/pins_with_various_options_importmap.rb
+++ b/test/fixtures/files/pins_with_various_options_importmap.rb
@@ -4,4 +4,4 @@ pin "md5", to: "https://cdn.skypack.dev/md5", preload: true # 1.0.2
 pin "not_there", to: "nowhere.js", preload: false # 1.9.1
 pin "some_file" # 0.2.1
 pin "another_file",to:'another_file.js' # @0.0.16
-pin "random", random_option: "foobar" # 7.7.7
+pin "random", random_option: "foobar", hello: "world" # 7.7.7

--- a/test/fixtures/files/pins_with_various_options_importmap.rb
+++ b/test/fixtures/files/pins_with_various_options_importmap.rb
@@ -1,0 +1,6 @@
+pin_all_from "app/assets/javascripts"
+
+pin "md5", to: "https://cdn.skypack.dev/md5", preload: true # 1.0.2
+pin "not_there", to: "nowhere.js", preload: false # 1.9.1
+pin "some_file" # 0.2.1
+pin "another_file",to:'another_file.js' # @0.0.16

--- a/test/fixtures/files/pins_with_various_options_importmap.rb
+++ b/test/fixtures/files/pins_with_various_options_importmap.rb
@@ -4,3 +4,4 @@ pin "md5", to: "https://cdn.skypack.dev/md5", preload: true # 1.0.2
 pin "not_there", to: "nowhere.js", preload: false # 1.9.1
 pin "some_file" # 0.2.1
 pin "another_file",to:'another_file.js' # @0.0.16
+pin "random", random_option: "foobar" # 7.7.7

--- a/test/packager_test.rb
+++ b/test/packager_test.rb
@@ -55,7 +55,7 @@ class Importmap::PackagerTest < ActiveSupport::TestCase
     assert_equal %(pin "react" # @17.0.2), @packager.vendored_pin_for("react", "https://cdn/react@17.0.2")
     assert_equal %(pin "javascript/react", to: "javascript--react.js" # @17.0.2), @packager.vendored_pin_for("javascript/react", "https://cdn/react@17.0.2")
     assert_equal %(pin "md5", preload: true # @2.1.3), @packager.vendored_pin_for("md5", "https://cdn/md5@2.1.3")
-    assert_equal %(pin "random", random_option: "foobar" # @8.8.8), @packager.vendored_pin_for("random", "https://cdn/random@8.8.8")
+    assert_equal %(pin "random", random_option: "foobar", hello: "world" # @8.8.8), @packager.vendored_pin_for("random", "https://cdn/random@8.8.8")
   end
 
   test "pin_options_for_package" do

--- a/test/packager_test.rb
+++ b/test/packager_test.rb
@@ -56,6 +56,7 @@ class Importmap::PackagerTest < ActiveSupport::TestCase
     assert_equal %(pin "javascript/react", to: "javascript--react.js" # @17.0.2), @packager.vendored_pin_for("javascript/react", "https://cdn/react@17.0.2")
     assert_equal %(pin "md5", preload: true # @2.1.3), @packager.vendored_pin_for("md5", "https://cdn/md5@2.1.3")
     assert_equal %(pin "random", random_option: "foobar", hello: "world" # @8.8.8), @packager.vendored_pin_for("random", "https://cdn/random@8.8.8")
+    assert_equal %(pin "javascript/typescript", preload: true, to: "javascript--typescript.js" # @0.0.1), @packager.vendored_pin_for("javascript/typescript", "https://cdn/typescript@0.0.1")
   end
 
   test "pin_options_for_package" do

--- a/test/packager_test.rb
+++ b/test/packager_test.rb
@@ -3,7 +3,7 @@ require "importmap/packager"
 require "minitest/mock"
 
 class Importmap::PackagerTest < ActiveSupport::TestCase
-  setup { @packager = Importmap::Packager.new(Rails.root.join("config/importmap.rb")) }
+  setup { @packager = Importmap::Packager.new(Rails.root.join("../fixtures/files/pins_with_various_options_importmap.rb")) }
 
   test "successful import with mock" do
     response = Class.new do
@@ -54,5 +54,12 @@ class Importmap::PackagerTest < ActiveSupport::TestCase
   test "vendored_pin_for" do
     assert_equal %(pin "react" # @17.0.2), @packager.vendored_pin_for("react", "https://cdn/react@17.0.2")
     assert_equal %(pin "javascript/react", to: "javascript--react.js" # @17.0.2), @packager.vendored_pin_for("javascript/react", "https://cdn/react@17.0.2")
+  end
+
+  test "pin_options_for_package" do
+    assert_equal ({ "to" => "https://cdn.skypack.dev/md5", "preload" => true }), @packager.pin_options_for_package('md5')
+    assert_equal ({ "to" => "nowhere.js", "preload" => false }), @packager.pin_options_for_package('not_there')
+    assert_equal ({ }), @packager.pin_options_for_package('some_file')
+    assert_equal ({ "to" => "another_file.js" }), @packager.pin_options_for_package('another_file')
   end
 end

--- a/test/packager_test.rb
+++ b/test/packager_test.rb
@@ -54,6 +54,7 @@ class Importmap::PackagerTest < ActiveSupport::TestCase
   test "vendored_pin_for" do
     assert_equal %(pin "react" # @17.0.2), @packager.vendored_pin_for("react", "https://cdn/react@17.0.2")
     assert_equal %(pin "javascript/react", to: "javascript--react.js" # @17.0.2), @packager.vendored_pin_for("javascript/react", "https://cdn/react@17.0.2")
+    assert_equal %(pin "md5", preload: true # @2.1.3), @packager.vendored_pin_for("md5", "https://cdn/md5@2.1.3")
   end
 
   test "pin_options_for_package" do

--- a/test/packager_test.rb
+++ b/test/packager_test.rb
@@ -55,6 +55,7 @@ class Importmap::PackagerTest < ActiveSupport::TestCase
     assert_equal %(pin "react" # @17.0.2), @packager.vendored_pin_for("react", "https://cdn/react@17.0.2")
     assert_equal %(pin "javascript/react", to: "javascript--react.js" # @17.0.2), @packager.vendored_pin_for("javascript/react", "https://cdn/react@17.0.2")
     assert_equal %(pin "md5", preload: true # @2.1.3), @packager.vendored_pin_for("md5", "https://cdn/md5@2.1.3")
+    assert_equal %(pin "random", random_option: "foobar" # @8.8.8), @packager.vendored_pin_for("random", "https://cdn/random@8.8.8")
   end
 
   test "pin_options_for_package" do


### PR DESCRIPTION
Closes https://github.com/rails/importmap-rails/issues/243

# Problem

When repinning a package, `importmap pin some_package_name`, the pin options are not carried over.

For example if the following pin already exists:

```ruby
# importmap.rb

pin "foobar", preload: false # 0.0.1
```

And the command is executed to update the pin to the latest version, `0.1.0`:

```bash
importmap pin foobar
```

The `importmap pin` replaces the `foobar` pinned line with the following:

```ruby
# importmap.rb

pin "foobar" # 0.1.0
```

When updating packages it requires additional effort by the developer to manually carry over the options.

# Expectation

The pin options should carry over.

For example if the following pin already exists:

```ruby
# importmap.rb

pin "foobar", preload: false # 0.0.1
```

And the command is executed to update the pin to the latest version, `0.1.0`:

```bash
importmap pin foobar
```

The `importmap pin` replaces the `foobar` pinned line with the following:

```ruby
# importmap.rb

pin "foobar", preload: false # 0.1.0
```

# Solution

Implement a method which extract the pin options from the matching line. Update the `vendored_pin_for` which is used by the `pin` rake task to output with the carried over pin options.