### PR TITLE
Add `--preload` option to pin command

### DIFF
--- a/lib/importmap/commands.rb
+++ b/lib/importmap/commands.rb
@@ -12,12 +12,13 @@ class Importmap::Commands < Thor
   desc "pin [*PACKAGES]", "Pin new packages"
   option :env, type: :string, aliases: :e, default: "production"
   option :from, type: :string, aliases: :f, default: "jspm"
+  option :preload, type: :string, repeatable: true, desc: "Can be used multiple times"
   def pin(*packages)
     if imports = packager.import(*packages, env: options[:env], from: options[:from])
       imports.each do |package, url|
         puts %(Pinning "#{package}" to #{packager.vendor_path}/#{package}.js via download from #{url})
         packager.download(package, url)
-        pin = packager.vendored_pin_for(package, url)
+        pin = packager.vendored_pin_for(package, url, options[:preload])
 
         if packager.packaged?(package)
           gsub_file("config/importmap.rb", /^pin "#{package}".*$/, pin, verbose: false)

--- a/lib/importmap/packager.rb
+++ b/lib/importmap/packager.rb
@@ -36,14 +36,14 @@ class Importmap::Packager
     %(pin "#{package}", to: "#{url}")
   end
 
-  def vendored_pin_for(package, url)
+  def vendored_pin_for(package, url, preloads = nil)
     filename = package_filename(package)
     version  = extract_package_version_from(url)
 
     if "#{package}.js" == filename
-      %(pin "#{package}" # #{version})
+      %(pin "#{package}"#{preload(preloads)} # #{version})
     else
-      %(pin "#{package}", to: "#{filename}" # #{version})
+      %(pin "#{package}", to: "#{filename}"#{preload(preloads)} # #{version})
     end
   end
 
@@ -63,6 +63,21 @@ class Importmap::Packager
   end
 
   private
+    def preload(preloads)
+      case Array(preloads)
+      in []
+        ""
+      in ["true"]
+        %(, preload: true)
+      in ["false"]
+        %(, preload: false)
+      in [string]
+        %(, preload: "#{string}")
+      else
+        %(, preload: #{preloads})
+      end
+    end
+
     def post_json(body)
       Net::HTTP.post(self.class.endpoint, body.to_json, "Content-Type" => "application/json")
     rescue => error

--- a/test/packager_test.rb
+++ b/test/packager_test.rb
@@ -54,5 +54,9 @@ class Importmap::PackagerTest < ActiveSupport::TestCase
   test "vendored_pin_for" do
     assert_equal %(pin "react" # @17.0.2), @packager.vendored_pin_for("react", "https://cdn/react@17.0.2")
     assert_equal %(pin "javascript/react", to: "javascript--react.js" # @17.0.2), @packager.vendored_pin_for("javascript/react", "https://cdn/react@17.0.2")
+    assert_equal %(pin "react", preload: true # @17.0.2), @packager.vendored_pin_for("react", "https://cdn/react@17.0.2", ["true"])
+    assert_equal %(pin "react", preload: false # @17.0.2), @packager.vendored_pin_for("react", "https://cdn/react@17.0.2", ["false"])
+    assert_equal %(pin "react", preload: "foo" # @17.0.2), @packager.vendored_pin_for("react", "https://cdn/react@17.0.2", ["foo"])
+    assert_equal %(pin "react", preload: ["foo", "bar"] # @17.0.2), @packager.vendored_pin_for("react", "https://cdn/react@17.0.2", ["foo", "bar"])
   end
 end


### PR DESCRIPTION
In the [HotDocs installer](https://github.com/3v0k4/hotdocs/blob/49c2f322eab16e05d6b7b5fea150d4627b55a1e9/lib/install/install.rb#L26), I'd like to specify the preload when `pin`ning a package. Otherwise, I'd need to manually fiddle with the `config/importmap.rb` file.

This PR takes care of two things:
- Fix the tests in the first commit
- Add the `--preload` option to `pin` (e.g., `bin/importmap pin --preload=false lunr`, `bin/importmap pin --preload=application --preload=alternate lunr`) in the second commit; see the test for the specifics on the behavior

Thanks for your work on this gem!