### PR TITLE
Catch failure HTTP responses on calls to the npm registry 

### DIFF
--- a/lib/importmap/npm.rb
+++ b/lib/importmap/npm.rb
@@ -76,17 +76,19 @@ class Importmap::Npm
       request = Net::HTTP::Get.new(uri)
       request["Content-Type"] = "application/json"
 
-      response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |http|
-        http.request(request)
-      }
+      response = begin
+        Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |http|
+          http.request(request)
+        }
+      rescue => error
+        raise HTTPError, "Unexpected transport error (#{error.class}: #{error.message})"
+      end
 
-      unless response.kind_of? Net::HTTPSuccess
+      unless response.code.to_i < 300
         raise HTTPError, "Unexpected error response #{response.code}: #{response.body}"
       end
 
       response.body
-    rescue => error
-      raise HTTPError, "Unexpected transport error (#{error.class}: #{error.message})"
     end
 
     def find_latest_version(response)
@@ -115,9 +117,11 @@ class Importmap::Npm
       return {} if body.empty?
 
       response = post_json(uri, body)
-      unless response.kind_of? Net::HTTPSuccess
+
+      unless response.code.to_i < 300
         raise HTTPError, "Unexpected error response #{response.code}: #{response.body}"
       end
+
       JSON.parse(response.body)
     end
 

--- a/lib/importmap/npm.rb
+++ b/lib/importmap/npm.rb
@@ -80,6 +80,10 @@ class Importmap::Npm
         http.request(request)
       }
 
+      unless response.kind_of? Net::HTTPSuccess
+        raise HTTPError, "Unexpected error response #{response.code}: #{response.body}"
+      end
+
       response.body
     rescue => error
       raise HTTPError, "Unexpected transport error (#{error.class}: #{error.message})"
@@ -111,6 +115,9 @@ class Importmap::Npm
       return {} if body.empty?
 
       response = post_json(uri, body)
+      unless response.kind_of? Net::HTTPSuccess
+        raise HTTPError, "Unexpected error response #{response.code}: #{response.body}"
+      end
       JSON.parse(response.body)
     end
 


### PR DESCRIPTION
And add a more descriptive error message.

Fixes #300 