### PR TITLE
Implement SRI support in importmap-rails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
 
     env:
       BUNDLE_GEMFILE: gemfiles/rails_${{ matrix.rails-version }}_${{ matrix.assets-pipeline }}.gemfile
+      ASSETS_PIPELINE: ${{ matrix.assets-pipeline }}
 
     steps:
       - uses: actions/checkout@v4

--- a/Appraisals
+++ b/Appraisals
@@ -17,7 +17,6 @@ end
 
 appraise "rails_7.0_propshaft" do
   gem "rails", github: "rails/rails", branch: "7-0-stable"
-  gem "propshaft"
   gem "sqlite3", "~> 1.4"
 end
 
@@ -29,7 +28,6 @@ end
 
 appraise "rails_7.1_propshaft" do
   gem "rails", "~> 7.1.0"
-  gem "propshaft"
 end
 
 appraise "rails_7.2_sprockets" do
@@ -40,7 +38,6 @@ end
 
 appraise "rails_7.2_propshaft" do
   gem "rails", "~> 7.2.0"
-  gem "propshaft"
 end
 
 appraise "rails_8.0_sprockets" do
@@ -51,7 +48,6 @@ end
 
 appraise "rails_8.0_propshaft" do
   gem "rails", "~> 8.0.0"
-  gem "propshaft"
 end
 
 appraise "rails_main_sprockets" do
@@ -62,5 +58,4 @@ end
 
 appraise "rails_main_propshaft" do
   gem "rails", github: "rails/rails", branch: "main"
-  gem "propshaft"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gemspec
 
 gem "rails"
-gem "propshaft"
+gem "propshaft", ">= 1.2.0"
 
 gem "sqlite3"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,13 +105,13 @@ GEM
     crass (1.0.6)
     date (3.4.1)
     drb (2.2.3)
-    erb (5.0.1)
+    erb (5.0.2)
     erubi (1.13.1)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    io-console (0.8.0)
+    io-console (0.8.1)
     irb (1.15.2)
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
@@ -150,11 +150,10 @@ GEM
     pp (0.6.2)
       prettyprint
     prettyprint (0.2.0)
-    propshaft (1.1.0)
+    propshaft (1.2.0)
       actionpack (>= 7.0.0)
       activesupport (>= 7.0.0)
       rack
-      railties (>= 7.0.0)
     psych (5.2.6)
       date
       stringio
@@ -257,7 +256,7 @@ DEPENDENCIES
   byebug
   capybara
   importmap-rails!
-  propshaft
+  propshaft (>= 1.2.0)
   rails
   rexml
   selenium-webdriver

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ For example:
 pin "react", to: "https://ga.jspm.io/npm:react@17.0.2/index.js"
 ```
 
-means "everytime you see `import React from "react"`
+means "every time you see `import React from "react"`
 change it to `import React from "https://ga.jspm.io/npm:react@17.0.2/index.js"`"
 
 ```js
@@ -302,7 +302,7 @@ Pin your js file:
 pin "checkout", preload: false
 ```
 
-Import your module on the specific page. Note: you'll likely want to use a `content_for` block on the specifc page/partial, then yield it in your layout.
+Import your module on the specific page. Note: you'll likely want to use a `content_for` block on the specific page/partial, then yield it in your layout.
 
 ```erb
 <% content_for :head do %>

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ import React from "./node_modules/react"
 import React from "https://ga.jspm.io/npm:react@17.0.1/index.js"
 ```
 
-Importmap-rails provides a clean API for mapping "bare module specifiers" like `"react"` 
+Importmap-rails provides a clean API for mapping "bare module specifiers" like `"react"`
 to 1 of the 3 viable ways of loading ES Module javascript packages.
 
 For example:
@@ -54,11 +54,11 @@ For example:
 pin "react", to: "https://ga.jspm.io/npm:react@17.0.2/index.js"
 ```
 
-means "everytime you see `import React from "react"` 
+means "everytime you see `import React from "react"`
 change it to `import React from "https://ga.jspm.io/npm:react@17.0.2/index.js"`"
 
 ```js
-import React from "react" 
+import React from "react"
 // => import React from "https://ga.jspm.io/npm:react@17.0.2/index.js"
 ```
 
@@ -129,6 +129,91 @@ If you later wish to remove a downloaded pin:
 ```bash
 ./bin/importmap unpin react
 Unpinning and removing "react"
+```
+
+## Subresource Integrity (SRI)
+
+For enhanced security, importmap-rails automatically includes [Subresource Integrity (SRI)](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) hashes by default when pinning packages. This ensures that JavaScript files loaded from CDNs haven't been tampered with.
+
+### Default behavior with integrity
+
+When you pin a package, integrity hashes are automatically included:
+
+```bash
+./bin/importmap pin lodash
+Pinning "lodash" to vendor/javascript/lodash.js via download from https://ga.jspm.io/npm:lodash@4.17.21/lodash.js
+  Using integrity: sha384-PkIkha4kVPRlGtFantHjuv+Y9mRefUHpLFQbgOYUjzy247kvi16kLR7wWnsAmqZF
+```
+
+This generates a pin in your `config/importmap.rb` with the integrity hash:
+
+```ruby
+pin "lodash", integrity: "sha384-PkIkha4kVPRlGtFantHjuv+Y9mRefUHpLFQbgOYUjzy247kvi16kLR7wWnsAmqZF" # @4.17.21
+```
+
+### Opting out of integrity
+
+If you need to disable integrity checking (not recommended for security reasons), you can use the `--no-integrity` flag:
+
+```bash
+./bin/importmap pin lodash --no-integrity
+Pinning "lodash" to vendor/javascript/lodash.js via download from https://ga.jspm.io/npm:lodash@4.17.21/lodash.js
+```
+
+This generates a pin without integrity:
+
+```ruby
+pin "lodash" # @4.17.21
+```
+
+### Adding integrity to existing pins
+
+If you have existing pins without integrity hashes, you can add them using the `integrity` command:
+
+```bash
+# Add integrity to specific packages
+./bin/importmap integrity lodash react
+
+# Add integrity to all pinned packages
+./bin/importmap integrity
+
+# Update your importmap.rb file with integrity hashes
+./bin/importmap integrity --update
+```
+
+### How integrity works
+
+The integrity hashes are automatically included in your import map and module preload tags:
+
+**Import map JSON:**
+```json
+{
+  "imports": {
+    "lodash": "https://ga.jspm.io/npm:lodash@4.17.21/lodash.js"
+  },
+  "integrity": {
+    "https://ga.jspm.io/npm:lodash@4.17.21/lodash.js": "sha384-PkIkha4kVPRlGtFantHjuv+Y9mRefUHpLFQbgOYUjzy247kvi16kLR7wWnsAmqZF"
+  }
+}
+```
+
+**Module preload tags:**
+```html
+<link rel="modulepreload" href="https://ga.jspm.io/npm:lodash@4.17.21/lodash.js" integrity="sha384-PkIkha4kVPRlGtFantHjuv+Y9mRefUHpLFQbgOYUjzy247kvi16kLR7wWnsAmqZF">
+```
+
+Modern browsers will automatically validate these integrity hashes when loading the JavaScript modules, ensuring the files haven't been modified.
+
+### Redownloading packages with integrity
+
+The `pristine` command also includes integrity by default:
+
+```bash
+# Redownload all packages with integrity (default)
+./bin/importmap pristine
+
+# Redownload packages without integrity
+./bin/importmap pristine --no-integrity
 ```
 
 ## Preloading pinned modules

--- a/gemfiles/rails_7.0_propshaft.gemfile
+++ b/gemfiles/rails_7.0_propshaft.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", branch: "7-0-stable", git: "https://github.com/rails/rails.git"
-gem "propshaft"
+gem "propshaft", ">= 1.2.0"
 gem "sqlite3", "~> 1.4"
 
 group :development do

--- a/gemfiles/rails_7.1_propshaft.gemfile
+++ b/gemfiles/rails_7.1_propshaft.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 7.1.0"
-gem "propshaft"
+gem "propshaft", ">= 1.2.0"
 gem "sqlite3"
 
 group :development do

--- a/gemfiles/rails_7.2_propshaft.gemfile
+++ b/gemfiles/rails_7.2_propshaft.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 7.2.0"
-gem "propshaft"
+gem "propshaft", ">= 1.2.0"
 gem "sqlite3"
 
 group :development do

--- a/gemfiles/rails_8.0_propshaft.gemfile
+++ b/gemfiles/rails_8.0_propshaft.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 8.0.0"
-gem "propshaft"
+gem "propshaft", ">= 1.2.0"
 gem "sqlite3"
 
 group :development do

--- a/gemfiles/rails_main_propshaft.gemfile
+++ b/gemfiles/rails_main_propshaft.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", branch: "main", git: "https://github.com/rails/rails.git"
-gem "propshaft"
+gem "propshaft", ">= 1.2.0"
 gem "sqlite3"
 
 group :development do

--- a/lib/importmap/commands.rb
+++ b/lib/importmap/commands.rb
@@ -13,21 +13,19 @@ class Importmap::Commands < Thor
   option :env, type: :string, aliases: :e, default: "production"
   option :from, type: :string, aliases: :f, default: "jspm"
   option :preload, type: :string, repeatable: true, desc: "Can be used multiple times"
+  option :integrity, type: :boolean, aliases: :i, default: true, desc: "Include integrity hash from JSPM"
   def pin(*packages)
-    if imports = packager.import(*packages, env: options[:env], from: options[:from])
-      imports.each do |package, url|
+    with_import_response(packages, env: options[:env], from: options[:from], integrity: options[:integrity]) do |imports, integrity_hashes|
+      process_imports(imports, integrity_hashes) do |package, url, integrity_hash|
         puts %(Pinning "#{package}" to #{packager.vendor_path}/#{package}.js via download from #{url})
-        packager.download(package, url)
-        pin = packager.vendored_pin_for(package, url, options[:preload])
 
-        if packager.packaged?(package)
-          gsub_file("config/importmap.rb", /^pin "#{package}".*$/, pin, verbose: false)
-        else
-          append_to_file("config/importmap.rb", "#{pin}\n", verbose: false)
-        end
+        packager.download(package, url)
+
+        pin = packager.vendored_pin_for(package, url, options[:preload], integrity: integrity_hash)
+
+        log_integrity_usage(integrity_hash)
+        update_importmap_with_pin(package, pin)
       end
-    else
-      puts "Couldn't find any packages in #{packages.inspect} on #{options[:from]}"
     end
   end
 
@@ -35,33 +33,31 @@ class Importmap::Commands < Thor
   option :env, type: :string, aliases: :e, default: "production"
   option :from, type: :string, aliases: :f, default: "jspm"
   def unpin(*packages)
-    if imports = packager.import(*packages, env: options[:env], from: options[:from])
+    with_import_response(packages, env: options[:env], from: options[:from]) do |imports, _integrity_hashes|
       imports.each do |package, url|
         if packager.packaged?(package)
           puts %(Unpinning and removing "#{package}")
           packager.remove(package)
         end
       end
-    else
-      puts "Couldn't find any packages in #{packages.inspect} on #{options[:from]}"
     end
   end
 
   desc "pristine", "Redownload all pinned packages"
   option :env, type: :string, aliases: :e, default: "production"
   option :from, type: :string, aliases: :f, default: "jspm"
+  option :integrity, type: :boolean, aliases: :i, default: true, desc: "Include integrity hash from JSPM"
   def pristine
-    packages = npm.packages_with_versions.map do |p, v|
-      v.blank? ? p : [p, v].join("@")
-    end
+    packages = prepare_packages_with_versions
 
-    if imports = packager.import(*packages, env: options[:env], from: options[:from])
-      imports.each do |package, url|
+    with_import_response(packages, env: options[:env], from: options[:from], integrity: options[:integrity]) do |imports, integrity_hashes|
+      process_imports(imports, integrity_hashes) do |package, url, integrity_hash|
         puts %(Downloading "#{package}" to #{packager.vendor_path}/#{package}.js from #{url})
+
         packager.download(package, url)
+
+        log_integrity_usage(integrity_hash)
       end
-    else
-      puts "Couldn't find any packages in #{packages.inspect} on #{options[:from]}"
     end
   end
 
@@ -122,6 +118,33 @@ class Importmap::Commands < Thor
     puts npm.packages_with_versions.map { |x| x.join(' ') }
   end
 
+  desc "integrity [*PACKAGES]", "Download and add integrity hashes for packages"
+  option :env, type: :string, aliases: :e, default: "production"
+  option :from, type: :string, aliases: :f, default: "jspm"
+  option :update, type: :boolean, aliases: :u, default: false, desc: "Update importmap.rb with integrity hashes"
+  def integrity(*packages)
+    packages = prepare_packages_with_versions(packages)
+
+    with_import_response(packages, env: options[:env], from: options[:from], integrity: true) do |imports, integrity_hashes|
+      process_imports(imports, integrity_hashes) do |package, url, integrity_hash|
+        puts %(Getting integrity for "#{package}" from #{url})
+
+        if integrity_hash
+          puts %(  #{package}: #{integrity_hash})
+
+          if options[:update]
+            pin_with_integrity = packager.pin_for(package, url, integrity: integrity_hash)
+
+            update_importmap_with_pin(package, pin_with_integrity)
+            puts %(  Updated importmap.rb with integrity for "#{package}")
+          end
+        else
+          puts %(  No integrity hash available for "#{package}")
+        end
+      end
+    end
+  end
+
   private
     def packager
       @packager ||= Importmap::Packager.new
@@ -129,6 +152,22 @@ class Importmap::Commands < Thor
 
     def npm
       @npm ||= Importmap::Npm.new
+    end
+
+    def update_importmap_with_pin(package, pin)
+      if packager.packaged?(package)
+        gsub_file("config/importmap.rb", /^pin "#{package}".*$/, pin, verbose: false)
+      else
+        append_to_file("config/importmap.rb", "#{pin}\n", verbose: false)
+      end
+    end
+
+    def log_integrity_usage(integrity_hash)
+      puts %(  Using integrity: #{integrity_hash}) if integrity_hash
+    end
+
+    def handle_package_not_found(packages, from)
+      puts "Couldn't find any packages in #{packages.inspect} on #{from}"
     end
 
     def remove_line_from_file(path, pattern)
@@ -153,6 +192,33 @@ class Importmap::Commands < Thor
         row = row.each_with_index.map { |v, i| v.to_s + " " * (column_sizes[i] - v.to_s.length) }
         puts "| " + row.join(" | ") + " |"
         puts divider if row_number == 0
+      end
+    end
+
+    def prepare_packages_with_versions(packages = [])
+      if packages.empty?
+        npm.packages_with_versions.map do |p, v|
+          v.blank? ? p : [p, v].join("@")
+        end
+      else
+        packages
+      end
+    end
+
+    def process_imports(imports, integrity_hashes, &block)
+      imports.each do |package, url|
+        integrity_hash = integrity_hashes[url]
+        block.call(package, url, integrity_hash)
+      end
+    end
+
+    def with_import_response(packages, **options)
+      response = packager.import(*packages, **options)
+
+      if response
+        yield response[:imports], response[:integrity]
+      else
+        handle_package_not_found(packages, options[:from])
       end
     end
 end

--- a/test/commands_test.rb
+++ b/test/commands_test.rb
@@ -8,7 +8,6 @@ class CommandsTest < ActiveSupport::TestCase
     @tmpdir = Dir.mktmpdir
     FileUtils.cp_r("#{__dir__}/dummy", @tmpdir)
     Dir.chdir("#{@tmpdir}/dummy")
-    FileUtils.cp("#{__dir__}/../lib/install/bin/importmap", "bin")
   end
 
   teardown do
@@ -16,32 +15,28 @@ class CommandsTest < ActiveSupport::TestCase
   end
 
   test "json command prints JSON with imports" do
-    out, err = run_importmap_command("json")
+    out, _err = run_importmap_command("json")
+
     assert_includes JSON.parse(out), "imports"
   end
 
   test "update command prints message of no outdated packages" do
     out, _err = run_importmap_command("update")
+
     assert_includes out, "No outdated"
   end
 
   test "update command prints confirmation of pin with outdated packages" do
-    @tmpdir = Dir.mktmpdir
-    FileUtils.cp_r("#{__dir__}/dummy", @tmpdir)
-    Dir.chdir("#{@tmpdir}/dummy")
     FileUtils.cp("#{__dir__}/fixtures/files/outdated_import_map.rb", "#{@tmpdir}/dummy/config/importmap.rb")
-    FileUtils.cp("#{__dir__}/../lib/install/bin/importmap", "bin")
 
     out, _err = run_importmap_command("update")
+
     assert_includes out, "Pinning"
   end
 
   test "pristine command redownloads all pinned packages" do
-    @tmpdir = Dir.mktmpdir
-    FileUtils.cp_r("#{__dir__}/dummy", @tmpdir)
-    Dir.chdir("#{@tmpdir}/dummy")
     FileUtils.cp("#{__dir__}/fixtures/files/outdated_import_map.rb", "#{@tmpdir}/dummy/config/importmap.rb")
-    FileUtils.cp("#{__dir__}/../lib/install/bin/importmap", "bin")
+
     out, _err = run_importmap_command("pin", "md5@2.2.0")
 
     assert_includes out, 'Pinning "md5" to vendor/javascript/md5.js via download from https://ga.jspm.io/npm:md5@2.2.0/md5.js'
@@ -53,6 +48,149 @@ class CommandsTest < ActiveSupport::TestCase
 
     assert_includes out, 'Downloading "md5" to vendor/javascript/md5.js from https://ga.jspm.io/npm:md5@2.2.0'
     assert_equal original, File.read("#{@tmpdir}/dummy/vendor/javascript/md5.js")
+  end
+
+  test "pin command includes integrity by default" do
+    out, _err = run_importmap_command("pin", "md5@2.2.0")
+
+    assert_includes out, 'Pinning "md5" to vendor/javascript/md5.js via download from https://ga.jspm.io/npm:md5@2.2.0/md5.js'
+    assert_includes out, 'Using integrity:'
+
+    config_content = File.read("#{@tmpdir}/dummy/config/importmap.rb")
+    assert_includes config_content, 'pin "md5", integrity: "sha384-'
+  end
+
+  test "pin command with --no-integrity option excludes integrity" do
+    out, _err = run_importmap_command("pin", "md5@2.2.0", "--no-integrity")
+
+    assert_includes out, 'Pinning "md5" to vendor/javascript/md5.js via download from https://ga.jspm.io/npm:md5@2.2.0/md5.js'
+    assert_not_includes out, 'Using integrity:'
+
+    config_content = File.read("#{@tmpdir}/dummy/config/importmap.rb")
+    assert_includes config_content, 'pin "md5" # @2.2.0'
+  end
+
+  test "pristine command includes integrity by default" do
+    FileUtils.cp("#{__dir__}/fixtures/files/outdated_import_map.rb", "#{@tmpdir}/dummy/config/importmap.rb")
+
+    out, _err = run_importmap_command("pristine")
+
+    assert_includes out, 'Downloading "md5" to vendor/javascript/md5.js from https://ga.jspm.io/npm:md5@2.2.0/md5.js'
+    assert_includes out, 'Using integrity:'
+  end
+
+  test "pristine command with --no-integrity option excludes integrity" do
+    FileUtils.cp("#{__dir__}/fixtures/files/outdated_import_map.rb", "#{@tmpdir}/dummy/config/importmap.rb")
+
+    out, _err = run_importmap_command("pristine", "--no-integrity")
+
+    assert_includes out, 'Downloading "md5" to vendor/javascript/md5.js from https://ga.jspm.io/npm:md5@2.2.0/md5.js'
+    assert_not_includes out, 'Using integrity:'
+  end
+
+  test "pin command with explicit --integrity option includes integrity" do
+    out, _err = run_importmap_command("pin", "md5@2.2.0", "--integrity")
+
+    assert_includes out, 'Pinning "md5" to vendor/javascript/md5.js via download from https://ga.jspm.io/npm:md5@2.2.0/md5.js'
+    assert_includes out, 'Using integrity:'
+
+    config_content = File.read("#{@tmpdir}/dummy/config/importmap.rb")
+    assert_includes config_content, 'integrity: "sha384-'
+  end
+
+  test "pin command with multiple packages includes integrity for all" do
+    out, _err = run_importmap_command("pin", "md5@2.2.0", "lodash@4.17.21")
+
+    assert_includes out, 'Pinning "md5"'
+    assert_includes out, 'Pinning "lodash"'
+    assert_includes out, 'Using integrity:'
+
+    config_content = File.read("#{@tmpdir}/dummy/config/importmap.rb")
+    assert_includes config_content, 'pin "md5"'
+    assert_includes config_content, 'pin "lodash"'
+
+    md5_lines = config_content.lines.select { |line| line.include?('pin "md5"') }
+    lodash_lines = config_content.lines.select { |line| line.include?('pin "lodash"') }
+    assert md5_lines.any? { |line| line.include?('integrity:') }
+    assert lodash_lines.any? { |line| line.include?('integrity:') }
+  end
+
+  test "pin command with preload option includes integrity and preload" do
+    out, _err = run_importmap_command("pin", "md5@2.2.0", "--preload", "true")
+
+    assert_includes out, 'Pinning "md5" to vendor/javascript/md5.js via download from https://ga.jspm.io/npm:md5@2.2.0/md5.js'
+    assert_includes out, 'Using integrity:'
+
+    config_content = File.read("#{@tmpdir}/dummy/config/importmap.rb")
+    assert_includes config_content, 'preload: true'
+    assert_includes config_content, 'integrity: "sha384-'
+  end
+
+  test "integrity command shows integrity hashes for specific packages" do
+    out, _err = run_importmap_command("integrity", "md5@2.2.0")
+
+    assert_includes out, 'Getting integrity for "md5" from https://ga.jspm.io/npm:md5@2.2.0/md5.js'
+    assert_includes out, 'md5: sha384-'
+  end
+
+  test "integrity command with --update option updates importmap.rb" do
+    config_content = File.read("#{@tmpdir}/dummy/config/importmap.rb")
+    assert_includes config_content, 'pin "md5", to: "https://cdn.skypack.dev/md5", preload: true'
+
+    out, _err = run_importmap_command("integrity", "md5@2.2.0", "--update")
+
+    assert_includes out, 'Getting integrity for "md5" from https://ga.jspm.io/npm:md5@2.2.0/md5.js'
+    assert_includes out, 'md5: sha384-'
+    assert_includes out, 'Updated importmap.rb with integrity for "md5"'
+
+    config_content = File.read("#{@tmpdir}/dummy/config/importmap.rb")
+    assert_includes config_content, 'pin "md5", to: "https://ga.jspm.io/npm:md5@2.2.0/md5.js", integrity: "sha384-'
+  end
+
+  test "integrity command with multiple packages shows integrity for all" do
+    out, _err = run_importmap_command("integrity", "md5@2.2.0", "lodash@4.17.21")
+
+    assert_includes out, 'Getting integrity for "md5"'
+    assert_includes out, 'Getting integrity for "lodash"'
+    assert_includes out, 'md5: sha384-'
+    assert_includes out, 'lodash: sha384-'
+  end
+
+  test "integrity command without packages shows integrity for all remote packages" do
+    run_importmap_command("pin", "md5@2.2.0", "--no-integrity")
+
+    out, _err = run_importmap_command("integrity")
+
+    assert_includes out, 'Getting integrity for "md5"'
+    assert_includes out, 'md5: sha384-'
+  end
+
+  test "integrity command with --update updates multiple packages" do
+    run_importmap_command("pin", "md5@2.2.0", "--no-integrity")
+    run_importmap_command("pin", "lodash@4.17.21", "--no-integrity")
+
+    out, _err = run_importmap_command("integrity", "--update")
+
+    assert_includes out, 'Updated importmap.rb with integrity for "md5"'
+    assert_includes out, 'Updated importmap.rb with integrity for "lodash"'
+
+    config_content = File.read("#{@tmpdir}/dummy/config/importmap.rb")
+    assert_includes config_content, 'pin "md5", to: "https://ga.jspm.io/npm:md5@2.2.0/md5.js", integrity: "sha384-'
+    assert_includes config_content, 'pin "lodash", to: "https://ga.jspm.io/npm:lodash@4.17.21/lodash.js", integrity: "sha384-'
+  end
+
+  test "integrity command with env option" do
+    out, _err = run_importmap_command("integrity", "md5@2.2.0", "--env", "development")
+
+    assert_includes out, 'Getting integrity for "md5"'
+    assert_includes out, 'md5: sha384-'
+  end
+
+  test "integrity command with from option" do
+    out, _err = run_importmap_command("integrity", "md5@2.2.0", "--from", "jspm")
+
+    assert_includes out, 'Getting integrity for "md5"'
+    assert_includes out, 'md5: sha384-'
   end
 
   private

--- a/test/dummy/bin/importmap
+++ b/test/dummy/bin/importmap
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+
+require_relative "../config/application"
+require "importmap/commands"

--- a/test/dummy/config/importmap.rb
+++ b/test/dummy/config/importmap.rb
@@ -2,3 +2,4 @@ pin_all_from "app/assets/javascripts"
 
 pin "md5", to: "https://cdn.skypack.dev/md5", preload: true
 pin "not_there", to: "nowhere.js", preload: false
+pin "rich_text", preload: true, integrity: "sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb"

--- a/test/dummy/config/initializers/assets.rb
+++ b/test/dummy/config/initializers/assets.rb
@@ -11,3 +11,5 @@ Rails.application.config.assets.paths << Rails.root.join("app/components")
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
+
+Rails.application.config.assets.integrity_hash_algorithm = "sha384"

--- a/test/importmap_tags_helper_test.rb
+++ b/test/importmap_tags_helper_test.rb
@@ -43,7 +43,7 @@ class Importmap::ImportmapTagsHelperTest < ActionView::TestCase
     assert_dom_equal(
       %(
         <link rel="modulepreload" href="https://cdn.skypack.dev/md5">
-        <link rel="modulepreload" href="/rich_text.js">
+        <link rel="modulepreload" href="/rich_text.js" integrity="sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb">
       ),
       javascript_importmap_module_preload_tags
     )

--- a/test/importmap_tags_helper_test.rb
+++ b/test/importmap_tags_helper_test.rb
@@ -52,7 +52,7 @@ class Importmap::ImportmapTagsHelperTest < ActionView::TestCase
   test "tags have no nonce if CSP is not configured" do
     @request = FakeRequest.new
 
-    assert_no_match /nonce/, javascript_importmap_tags("application")
+    assert_no_match(/nonce/, javascript_importmap_tags("application"))
   ensure
     @request = nil
   end
@@ -60,9 +60,9 @@ class Importmap::ImportmapTagsHelperTest < ActionView::TestCase
   test "tags have nonce if CSP is configured" do
     @request = FakeRequest.new("iyhD0Yc0W+c=")
 
-    assert_match /nonce="iyhD0Yc0W\+c="/, javascript_inline_importmap_tag
-    assert_match /nonce="iyhD0Yc0W\+c="/, javascript_import_module_tag("application")
-    assert_match /nonce="iyhD0Yc0W\+c="/, javascript_importmap_module_preload_tags
+    assert_match(/nonce="iyhD0Yc0W\+c="/, javascript_inline_importmap_tag)
+    assert_match(/nonce="iyhD0Yc0W\+c="/, javascript_import_module_tag("application"))
+    assert_match(/nonce="iyhD0Yc0W\+c="/, javascript_importmap_module_preload_tags)
   ensure
     @request = nil
   end

--- a/test/importmap_tags_helper_test.rb
+++ b/test/importmap_tags_helper_test.rb
@@ -20,15 +20,33 @@ class Importmap::ImportmapTagsHelperTest < ActionView::TestCase
   end
 
   test "javascript_inline_importmap_tag" do
-    assert_match \
-      %r{<script type="importmap" data-turbo-track="reload">{\n  \"imports\": {\n    \"md5\": \"https://cdn.skypack.dev/md5\",\n    \"not_there\": \"/nowhere.js\"\n  }\n}</script>},
+    assert_dom_equal(
+      %(
+      <script type="importmap" data-turbo-track="reload">
+        {
+          "imports": {
+            "md5": "https://cdn.skypack.dev/md5",
+            "not_there": "/nowhere.js",
+            "rich_text": "/rich_text.js"
+          },
+          "integrity": {
+            "/rich_text.js": "sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb"
+          }
+        }
+      </script>
+      ),
       javascript_inline_importmap_tag
+    )
   end
 
   test "javascript_importmap_module_preload_tags" do
-    assert_dom_equal \
-      %(<link rel="modulepreload" href="https://cdn.skypack.dev/md5">),
+    assert_dom_equal(
+      %(
+        <link rel="modulepreload" href="https://cdn.skypack.dev/md5">
+        <link rel="modulepreload" href="/rich_text.js">
+      ),
       javascript_importmap_module_preload_tags
+    )
   end
 
   test "tags have no nonce if CSP is not configured" do

--- a/test/importmap_test.rb
+++ b/test/importmap_test.rb
@@ -99,35 +99,35 @@ class ImportmapTest < ActiveSupport::TestCase
 
   test "preloaded modules are included in preload tags when no entry_point specified" do
     preloading_module_paths = @importmap.preloaded_module_paths(resolver: ApplicationController.helpers).to_s
-    assert_match /md5/, preloading_module_paths
-    assert_match /goodbye_controller/, preloading_module_paths
-    assert_match /leaflet/, preloading_module_paths
-    assert_no_match /application/, preloading_module_paths
-    assert_no_match /tinymce/, preloading_module_paths
+    assert_match(/md5/, preloading_module_paths)
+    assert_match(/goodbye_controller/, preloading_module_paths)
+    assert_match(/leaflet/, preloading_module_paths)
+    assert_no_match(/application/, preloading_module_paths)
+    assert_no_match(/tinymce/, preloading_module_paths)
   end
 
   test "preloaded modules are included in preload tags based on single entry_point provided" do
     preloading_module_paths = @importmap.preloaded_module_paths(resolver: ApplicationController.helpers, entry_point: "alternate").to_s
-    assert_no_match /leaflet/, preloading_module_paths
-    assert_match /tinymce/, preloading_module_paths
-    assert_match /chartkick/, preloading_module_paths
-    assert_match /md5/, preloading_module_paths
-    assert_match /goodbye_controller/, preloading_module_paths
-    assert_no_match /application/, preloading_module_paths
+    assert_no_match(/leaflet/, preloading_module_paths)
+    assert_match(/tinymce/, preloading_module_paths)
+    assert_match(/chartkick/, preloading_module_paths)
+    assert_match(/md5/, preloading_module_paths)
+    assert_match(/goodbye_controller/, preloading_module_paths)
+    assert_no_match(/application/, preloading_module_paths)
   end
 
   test "preloaded modules are included in preload tags based on multiple entry_points provided" do
     preloading_module_paths = @importmap.preloaded_module_paths(resolver: ApplicationController.helpers, entry_point: ["application", "alternate"]).to_s
-    assert_match /leaflet/, preloading_module_paths
-    assert_match /tinymce/, preloading_module_paths
-    assert_match /chartkick/, preloading_module_paths
-    assert_match /md5/, preloading_module_paths
-    assert_match /goodbye_controller/, preloading_module_paths
-    assert_no_match /application/, preloading_module_paths
+    assert_match(/leaflet/, preloading_module_paths)
+    assert_match(/tinymce/, preloading_module_paths)
+    assert_match(/chartkick/, preloading_module_paths)
+    assert_match(/md5/, preloading_module_paths)
+    assert_match(/goodbye_controller/, preloading_module_paths)
+    assert_no_match(/application/, preloading_module_paths)
   end
 
   test "digest" do
-    assert_match /^\w{40}$/, @importmap.digest(resolver: ApplicationController.helpers)
+    assert_match(/^\w{40}$/, @importmap.digest(resolver: ApplicationController.helpers))
   end
 
   test "separate caches" do

--- a/test/importmap_test.rb
+++ b/test/importmap_test.rb
@@ -152,6 +152,133 @@ class ImportmapTest < ActiveSupport::TestCase
     assert_not_equal set_two, @importmap.preloaded_module_paths(resolver: ApplicationController.helpers, cache_key: "2").to_s
   end
 
+  test "preloaded_module_packages returns hash of resolved paths to packages when no entry_point specified" do
+    packages = @importmap.preloaded_module_packages(resolver: ApplicationController.helpers)
+
+    md5 = packages["https://cdn.skypack.dev/md5"]
+    assert md5, "Should include md5 package"
+    assert_equal "md5", md5.name
+    assert_equal "https://cdn.skypack.dev/md5", md5.path
+    assert_equal true, md5.preload
+
+    goodbye_controller_path = packages.keys.find { |path| path.include?("goodbye_controller") }
+    assert goodbye_controller_path, "Should include goodbye_controller package"
+    assert_equal "controllers/goodbye_controller", packages[goodbye_controller_path].name
+    assert_equal true, packages[goodbye_controller_path].preload
+
+    leaflet = packages["https://cdn.skypack.dev/leaflet"]
+    assert leaflet, "Should include leaflet package"
+    assert_equal "leaflet", leaflet.name
+    assert_equal "https://cdn.skypack.dev/leaflet", leaflet.path
+    assert_equal 'application', leaflet.preload
+
+    chartkick = packages["https://cdn.skypack.dev/chartkick"]
+    assert chartkick, "Should include chartkick package"
+    assert_equal "chartkick", chartkick.name
+    assert_equal ['application', 'alternate'], chartkick.preload
+
+    application_path = packages.keys.find { |path| path.include?("application") }
+    assert_nil application_path, "Should not include application package (preload: false)"
+
+    tinymce_path = packages.keys.find { |path| path.include?("tinymce") }
+    assert_nil tinymce_path, "Should not include tinymce package (preload: 'alternate')"
+  end
+
+  test "preloaded_module_packages returns hash based on single entry_point provided" do
+    packages = @importmap.preloaded_module_packages(resolver: ApplicationController.helpers, entry_point: "alternate")
+
+    tinymce = packages["https://cdn.skypack.dev/tinymce"]
+    assert tinymce, "Should include tinymce package for alternate entry point"
+    assert_equal "tinyMCE", tinymce.name
+    assert_equal "https://cdn.skypack.dev/tinymce", tinymce.path
+    assert_equal 'alternate', tinymce.preload
+
+    # Should include packages for multiple entry points (chartkick preloads for both 'application' and 'alternate')
+    chartkick = packages["https://cdn.skypack.dev/chartkick"]
+    assert chartkick, "Should include chartkick package"
+    assert_equal "chartkick", chartkick.name
+    assert_equal ['application', 'alternate'], chartkick.preload
+
+    # Should include always-preloaded packages
+    md5 = packages["https://cdn.skypack.dev/md5"]
+    assert md5, "Should include md5 package (always preloaded)"
+
+    leaflet_path = packages.keys.find { |path| path.include?("leaflet") }
+    assert_nil leaflet_path, "Should not include leaflet package (preload: 'application' only)"
+  end
+
+  test "preloaded_module_packages returns hash based on multiple entry_points provided" do
+    packages = @importmap.preloaded_module_packages(resolver: ApplicationController.helpers, entry_point: ["application", "alternate"])
+
+    leaflet = packages["https://cdn.skypack.dev/leaflet"]
+    assert leaflet, "Should include leaflet package for application entry point"
+
+    # Should include packages for 'alternate' entry point
+    tinymce = packages["https://cdn.skypack.dev/tinymce"]
+    assert tinymce, "Should include tinymce package for alternate entry point"
+
+    # Should include packages for multiple entry points
+    chartkick = packages["https://cdn.skypack.dev/chartkick"]
+    assert chartkick, "Should include chartkick package for both entry points"
+
+    # Should include always-preloaded packages
+    md5 = packages["https://cdn.skypack.dev/md5"]
+    assert md5, "Should include md5 package (always preloaded)"
+
+    application_path = packages.keys.find { |path| path.include?("application") }
+    assert_nil application_path, "Should not include application package (preload: false)"
+  end
+
+  test "preloaded_module_packages includes package integrity when present" do
+    # Create a new importmap with a preloaded package that has integrity
+    importmap = Importmap::Map.new.tap do |map|
+      map.pin "editor", to: "rich_text.js", preload: true, integrity: "sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb"
+    end
+
+    packages = importmap.preloaded_module_packages(resolver: ApplicationController.helpers)
+
+    editor_path = packages.keys.find { |path| path.include?("rich_text") }
+    assert editor_path, "Should include editor package"
+    assert_equal "editor", packages[editor_path].name
+    assert_equal "sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb", packages[editor_path].integrity
+  end
+
+  test "preloaded_module_packages uses custom cache_key" do
+    set_one = @importmap.preloaded_module_packages(resolver: ApplicationController.helpers, cache_key: "1").to_s
+
+    ActionController::Base.asset_host = "http://assets.example.com"
+
+    set_two = @importmap.preloaded_module_packages(resolver: ActionController::Base.helpers, cache_key: "2").to_s
+
+    assert_not_equal set_one, set_two
+  ensure
+    ActionController::Base.asset_host = nil
+  end
+
+  test "preloaded_module_packages caches reset" do
+    set_one = @importmap.preloaded_module_packages(resolver: ApplicationController.helpers, cache_key: "1").to_s
+    set_two = @importmap.preloaded_module_packages(resolver: ApplicationController.helpers, cache_key: "2").to_s
+
+    @importmap.pin "something", to: "https://cdn.example.com/somewhere.js", preload: true
+
+    assert_not_equal set_one, @importmap.preloaded_module_packages(resolver: ApplicationController.helpers, cache_key: "1").to_s
+    assert_not_equal set_two, @importmap.preloaded_module_packages(resolver: ApplicationController.helpers, cache_key: "2").to_s
+  end
+
+  test "preloaded_module_packages handles missing assets gracefully" do
+    importmap = Importmap::Map.new.tap do |map|
+      map.pin "existing", to: "application.js", preload: true
+      map.pin "missing", to: "nonexistent.js", preload: true
+    end
+
+    packages = importmap.preloaded_module_packages(resolver: ApplicationController.helpers)
+
+    assert_equal 1, packages.size
+
+    existing_path = packages.keys.find { |path| path&.include?("application") }
+    assert existing_path, "Should include existing asset"
+  end
+
   private
     def generate_importmap_json
       @generate_importmap_json ||= JSON.parse @importmap.to_json(resolver: ApplicationController.helpers)

--- a/test/packager_integration_test.rb
+++ b/test/packager_integration_test.rb
@@ -5,7 +5,8 @@ class Importmap::PackagerIntegrationTest < ActiveSupport::TestCase
   setup { @packager = Importmap::Packager.new(Rails.root.join("config/importmap.rb")) }
 
   test "successful import against live service" do
-    assert_equal "https://ga.jspm.io/npm:react@17.0.2/index.js", @packager.import("react@17.0.2")["react"]
+    result = @packager.import("react@17.0.2")
+    assert_equal "https://ga.jspm.io/npm:react@17.0.2/index.js", result[:imports]["react"]
   end
 
   test "missing import against live service" do
@@ -40,7 +41,6 @@ class Importmap::PackagerIntegrationTest < ActiveSupport::TestCase
       @packager.download("react", package_url)
       assert File.exist?(vendored_package_file)
       assert_equal "// react@17.0.2 downloaded from #{package_url}", File.readlines(vendored_package_file).first.strip
-      
       @packager.remove("react")
       assert_not File.exist?(Pathname.new(vendor_dir).join("react.js"))
     end

--- a/test/packager_test.rb
+++ b/test/packager_test.rb
@@ -22,7 +22,9 @@ class Importmap::PackagerTest < ActiveSupport::TestCase
     end.new
 
     @packager.stub(:post_json, response) do
-      assert_equal(response.imports, @packager.import("react@17.0.2"))
+      result = @packager.import("react@17.0.2")
+      assert_equal response.imports, result[:imports]
+      assert_equal({}, result[:integrity])
     end
   end
 
@@ -49,6 +51,51 @@ class Importmap::PackagerTest < ActiveSupport::TestCase
 
   test "pin_for" do
     assert_equal %(pin "react", to: "https://cdn/react"), @packager.pin_for("react", "https://cdn/react")
+    assert_equal(
+      %(pin "react", to: "https://cdn/react", integrity: "sha384-abcdef"),
+      @packager.pin_for("react", "https://cdn/react", integrity: "sha384-abcdef")
+    )
+    assert_equal(
+      %(pin "react", to: "https://cdn/react"),
+      @packager.pin_for("react", "https://cdn/react", integrity: nil)
+    )
+    assert_equal(
+      %(pin "react", to: "https://cdn/react", preload: true),
+      @packager.pin_for("react", "https://cdn/react", preloads: ["true"])
+    )
+    assert_equal(
+      %(pin "react", to: "https://cdn/react", preload: false),
+      @packager.pin_for("react", "https://cdn/react", preloads: ["false"])
+    )
+    assert_equal(
+      %(pin "react", to: "https://cdn/react", preload: "foo"),
+      @packager.pin_for("react", "https://cdn/react", preloads: ["foo"])
+    )
+    assert_equal(
+      %(pin "react", to: "https://cdn/react", preload: ["foo", "bar"]),
+      @packager.pin_for("react", "https://cdn/react", preloads: ["foo", "bar"])
+    )
+    assert_equal(
+      %(pin "react", to: "https://cdn/react", preload: true, integrity: "sha384-abcdef"),
+      @packager.pin_for("react", "https://cdn/react", preloads: ["true"], integrity: "sha384-abcdef")
+    )
+    assert_equal(
+      %(pin "react", to: "https://cdn/react", preload: false, integrity: "sha384-abcdef"),
+      @packager.pin_for("react", "https://cdn/react", preloads: ["false"], integrity: "sha384-abcdef")
+    )
+    assert_equal(
+      %(pin "react", to: "https://cdn/react", preload: "foo", integrity: "sha384-abcdef"),
+      @packager.pin_for("react", "https://cdn/react", preloads: ["foo"], integrity: "sha384-abcdef")
+    )
+    assert_equal(
+      %(pin "react", to: "https://cdn/react", preload: ["foo", "bar"], integrity: "sha384-abcdef"),
+      @packager.pin_for("react", "https://cdn/react", preloads: ["foo", "bar"], integrity: "sha384-abcdef")
+    )
+
+    assert_equal %(pin "react"), @packager.pin_for("react")
+    assert_equal %(pin "react", preload: true), @packager.pin_for("react", preloads: ["true"])
+    assert_equal %(pin "react", integrity: "sha384-abcdef"), @packager.pin_for("react", integrity: "sha384-abcdef")
+    assert_equal %(pin "react", preload: true, integrity: "sha384-abcdef"), @packager.pin_for("react", preloads: ["true"], integrity: "sha384-abcdef")
   end
 
   test "vendored_pin_for" do
@@ -58,5 +105,71 @@ class Importmap::PackagerTest < ActiveSupport::TestCase
     assert_equal %(pin "react", preload: false # @17.0.2), @packager.vendored_pin_for("react", "https://cdn/react@17.0.2", ["false"])
     assert_equal %(pin "react", preload: "foo" # @17.0.2), @packager.vendored_pin_for("react", "https://cdn/react@17.0.2", ["foo"])
     assert_equal %(pin "react", preload: ["foo", "bar"] # @17.0.2), @packager.vendored_pin_for("react", "https://cdn/react@17.0.2", ["foo", "bar"])
+    assert_equal(
+      %(pin "react", integrity: "sha384-abcdef" # @17.0.2),
+      @packager.vendored_pin_for("react", "https://cdn/react@17.0.2", nil, integrity: "sha384-abcdef")
+    )
+    assert_equal(
+      %(pin "javascript/react", to: "javascript--react.js", integrity: "sha384-abcdef" # @17.0.2),
+      @packager.vendored_pin_for("javascript/react", "https://cdn/react@17.0.2", nil, integrity: "sha384-abcdef")
+    )
+    assert_equal(
+      %(pin "react", preload: true, integrity: "sha384-abcdef" # @17.0.2),
+      @packager.vendored_pin_for("react", "https://cdn/react@17.0.2", ["true"], integrity: "sha384-abcdef")
+    )
+    assert_equal(
+      %(pin "react", preload: false, integrity: "sha384-abcdef" # @17.0.2),
+      @packager.vendored_pin_for("react", "https://cdn/react@17.0.2", ["false"], integrity: "sha384-abcdef")
+    )
+    assert_equal(
+      %(pin "react", preload: "foo", integrity: "sha384-abcdef" # @17.0.2),
+      @packager.vendored_pin_for("react", "https://cdn/react@17.0.2", ["foo"], integrity: "sha384-abcdef")
+    )
+    assert_equal(
+      %(pin "react", preload: ["foo", "bar"], integrity: "sha384-abcdef" # @17.0.2),
+      @packager.vendored_pin_for("react", "https://cdn/react@17.0.2", ["foo", "bar"], integrity: "sha384-abcdef")
+    )
+    assert_equal(
+      %(pin "react" # @17.0.2),
+      @packager.vendored_pin_for("react", "https://cdn/react@17.0.2", nil, integrity: nil)
+    )
+  end
+
+  test "import with integrity parameter" do
+    response = Class.new do
+      def body
+        {
+          "map" => {
+            "imports" => imports,
+            "integrity" => integrity_map
+          }
+        }.to_json
+      end
+
+      def imports
+        {
+          "react" => "https://ga.jspm.io/npm:react@17.0.2/index.js",
+          "object-assign" => "https://ga.jspm.io/npm:object-assign@4.1.1/index.js"
+        }
+      end
+
+      def integrity_map
+        {
+          "https://ga.jspm.io/npm:react@17.0.2/index.js" => "sha384-abcdef1234567890",
+          "https://ga.jspm.io/npm:object-assign@4.1.1/index.js" => "sha384-1234567890abcdef"
+        }
+      end
+
+      def code() "200" end
+    end.new
+
+    @packager.stub(:post_json, response) do
+      result = @packager.import("react@17.0.2", integrity: true)
+      assert_equal response.imports, result[:imports]
+      assert_equal({
+        "https://ga.jspm.io/npm:react@17.0.2/index.js" => "sha384-abcdef1234567890",
+        "https://ga.jspm.io/npm:object-assign@4.1.1/index.js" => "sha384-1234567890abcdef"
+      }, result[:integrity])
+    end
   end
 end

--- a/test/reloader_test.rb
+++ b/test/reloader_test.rb
@@ -16,7 +16,7 @@ class ReloaderTest < ActiveSupport::TestCase
     Rails.application.importmap = Importmap::Map.new.draw { pin "md5", to: "https://cdn.skypack.dev/md5" }
     assert_not_predicate @reloader, :updated?
 
-    assert_changes -> { Rails.application.importmap.packages.keys }, from: %w[ md5 ], to: %w[ md5 not_there ] do
+    assert_changes -> { Rails.application.importmap.packages.keys }, from: %w[ md5 ], to: %w[ md5 not_there rich_text ] do
       touch_config
       assert @reloader.execute_if_updated
     end


### PR DESCRIPTION
This pull request introduces Subresource Integrity (SRI) support to the importmap-rails gem, enhancing security by ensuring that JavaScript files loaded from CDNs have not been tampered with.

### Default behavior with integrity

When you pin a package, integrity hashes are automatically included:

```bash
./bin/importmap pin lodash
Pinning "lodash" to vendor/javascript/lodash.js via download from https://ga.jspm.io/npm:lodash@4.17.21/lodash.js
  Using integrity: sha384-PkIkha4kVPRlGtFantHjuv+Y9mRefUHpLFQbgOYUjzy247kvi16kLR7wWnsAmqZF
```

This generates a pin in your `config/importmap.rb` with the integrity hash:

```ruby
pin "lodash", integrity: "sha384-PkIkha4kVPRlGtFantHjuv+Y9mRefUHpLFQbgOYUjzy247kvi16kLR7wWnsAmqZF" # @4.17.21
```

### Opting out of integrity

If you need to disable integrity checking (not recommended for security reasons), you can use the `--no-integrity` flag:

```bash
./bin/importmap pin lodash --no-integrity
Pinning "lodash" to vendor/javascript/lodash.js via download from https://ga.jspm.io/npm:lodash@4.17.21/lodash.js
```

This generates a pin without integrity:

```ruby
pin "lodash" # @4.17.21
```

### Adding integrity to existing pins

If you have existing pins without integrity hashes, you can add them using the `integrity` command:

```bash
# Add integrity to specific packages
./bin/importmap integrity lodash react

# Add integrity to all pinned packages
./bin/importmap integrity

# Update your importmap.rb file with integrity hashes
./bin/importmap integrity --update
```

### Automatic integrity for local assets

For local assets served by the Rails asset pipeline (like those created with `pin` or `pin_all_from`), you can use `integrity: true` to automatically calculate integrity hashes from the compiled assets:

```ruby
# config/importmap.rb

# Automatically calculate integrity from asset pipeline
pin "application", integrity: true
pin "admin", to: "admin.js", integrity: true

# Works with pin_all_from too
pin_all_from "app/javascript/controllers", under: "controllers", integrity: true
pin_all_from "app/javascript/lib", under: "lib", integrity: true

# Mixed usage
pin "local_module", integrity: true              # Auto-calculated
pin "cdn_package", integrity: "sha384-abc123..." # Pre-calculated
pin "no_integrity_package"                       # No integrity (default)
```

This is particularly useful for:
* **Local JavaScript files** managed by your Rails asset pipeline
* **Bulk operations** with `pin_all_from` where calculating hashes manually would be tedious
* **Development workflow** where asset contents change frequently

The `integrity: true` option:
* Uses the Rails asset pipeline's built-in integrity calculation
* Works with both Sprockets and Propshaft
* Automatically updates when assets are recompiled
* Gracefully handles missing assets (returns `nil` for non-existent files)

**Example output with `integrity: true`:**
```json
{
  "imports": {
    "application": "/assets/application-abc123.js",
    "controllers/hello_controller": "/assets/controllers/hello_controller-def456.js"
  },
  "integrity": {
    "/assets/application-abc123.js": "sha256-xyz789...",
    "/assets/controllers/hello_controller-def456.js": "sha256-uvw012..."
  }
}
```

### How integrity works

The integrity hashes are automatically included in your import map and module preload tags:

Import map JSON:

```json
{
  "imports": {
    "lodash": "https://ga.jspm.io/npm:lodash@4.17.21/lodash.js"
  },
  "integrity": {
    "https://ga.jspm.io/npm:lodash@4.17.21/lodash.js": "sha384-PkIkha4kVPRlGtFantHjuv+Y9mRefUHpLFQbgOYUjzy247kvi16kLR7wWnsAmqZF"
  }
}
```

Module preload tags:

```html
<link rel="modulepreload" href="https://ga.jspm.io/npm:lodash@4.17.21/lodash.js" integrity="sha384-PkIkha4kVPRlGtFantHjuv+Y9mRefUHpLFQbgOYUjzy247kvi16kLR7wWnsAmqZF">
```

Modern browsers will automatically validate these integrity hashes when loading the JavaScript modules, ensuring the files haven't been modified.

Closes #297.