### PR TITLE
Warn about vendored versionless packages

### DIFF
--- a/test/fixtures/files/import_map_without_cdn_and_versions.rb
+++ b/test/fixtures/files/import_map_without_cdn_and_versions.rb
@@ -1,0 +1,2 @@
+pin "foo", preload: true
+pin "@bar/baz", to: "baz.js", preload: true

--- a/test/npm_test.rb
+++ b/test/npm_test.rb
@@ -46,23 +46,22 @@ class Importmap::NpmTest < ActiveSupport::TestCase
     end
   end
 
-  test "missing outdated packages with mock" do
-    response = { "error" => "Not found" }.to_json
+  test "warns (and ignores) vendored packages without version" do
+    Dir.mktmpdir do |vendor_path|
+      with_vendored_package(vendor_path, "foo.js") do |foo_path|
+        with_vendored_package(vendor_path, "baz.js") do |baz_path|
+          npm = Importmap::Npm.new(file_fixture("import_map_without_cdn_and_versions.rb"), vendor_path: vendor_path)
 
-    @npm.stub(:get_json, response) do
-      outdated_packages = @npm.outdated_packages
+          outdated_packages = []
+          stdout, _stderr = capture_io { outdated_packages = npm.outdated_packages }
 
-      assert_equal(1, outdated_packages.size)
-      assert_equal('md5', outdated_packages[0].name)
-      assert_equal('2.2.0', outdated_packages[0].current_version)
-      assert_equal('Not found', outdated_packages[0].error)
-    end
-  end
-
-  test "failed outdated packages request with exception" do
-    Net::HTTP.stub(:start, proc { raise "Unexpected Error" }) do
-      assert_raises(Importmap::Npm::HTTPError) do
-        @npm.outdated_packages
+          expected = [
+            "Ignoring foo (#{foo_path}) since no version is specified in the importmap\n",
+            "Ignoring @bar/baz (#{baz_path}) since no version is specified in the importmap\n"
+          ]
+          assert_equal(expected, stdout.lines)
+          assert_equal(0, outdated_packages.size)
+        end
       end
     end
   end
@@ -141,5 +140,13 @@ class Importmap::NpmTest < ActiveSupport::TestCase
 
       assert_equal('version not found', outdated_packages[0].latest_version)
     end
+  end
+
+  def with_vendored_package(dir, name)
+    path = File.join(dir, name)
+    File.write(path, "console.log(123)")
+    yield path
+  ensure
+    File.delete(path)
   end
 end


### PR DESCRIPTION
Hey, first of all, thanks for your work on this gem 🙏

In my project, I got a vendored `bootstap` as follows:

```ruby
# config/importmap.rb
pin "bootstrap", preload: true
```

Problem is, without the version, `audit and `outdated` (and `pristine`) ignored that package. Which, is not great because not only the vendored version (v3.4.1) is outdated, but also because it has a vulnerability.

If I change the importmap to:

```ruby
# config/importmap.rb
pin "bootstrap", preload: true # @3.4.1
```

Then, I can see the `audit`:

```
| Package   | Severity | Vulnerable versions | Vulnerability                                      |
|-----------|----------|---------------------|----------------------------------------------------|
| bootstrap | moderate | >=2.0.0 <=3.4.1     | Bootstrap Cross-Site Scripting (XSS) vulnerability |
  1 vulnerability found: 1 moderate
```

This PR adds a warning about versionless vendored packages for that reason.