### PR TITLE
Keep options when updating packages in importmap

### DIFF
--- a/lib/importmap/commands.rb
+++ b/lib/importmap/commands.rb
@@ -117,10 +117,12 @@ class Importmap::Commands < Thor
     end
 
     def update_importmap_with_pin(package, pin)
+      new_pin = "#{pin}\n"
+
       if packager.packaged?(package)
-        gsub_file("config/importmap.rb", /^pin "#{package}".*$/, pin, verbose: false)
+        gsub_file("config/importmap.rb", Importmap::Map.pin_line_regexp_for(package), new_pin, verbose: false)
       else
-        append_to_file("config/importmap.rb", "#{pin}\n", verbose: false)
+        append_to_file("config/importmap.rb", new_pin, verbose: false)
       end
     end
 

--- a/lib/importmap/map.rb
+++ b/lib/importmap/map.rb
@@ -3,6 +3,12 @@ require "pathname"
 class Importmap::Map
   attr_reader :packages, :directories
 
+  PIN_REGEX = /^pin\s+["']([^"']+)["']/.freeze # :nodoc:
+
+  def self.pin_line_regexp_for(package) # :nodoc:
+    /^.*pin\s+["']#{Regexp.escape(package)}["'].*$/.freeze
+  end
+
   class InvalidFile < StandardError; end
 
   def initialize

--- a/lib/importmap/npm.rb
+++ b/lib/importmap/npm.rb
@@ -3,7 +3,7 @@ require "uri"
 require "json"
 
 class Importmap::Npm
-  PIN_REGEX = /^pin ["']([^["']]*)["'].*/
+  PIN_REGEX = /#{Importmap::Map::PIN_REGEX}.*/.freeze # :nodoc:
 
   Error     = Class.new(StandardError)
   HTTPError = Class.new(Error)

--- a/lib/importmap/npm.rb
+++ b/lib/importmap/npm.rb
@@ -51,7 +51,7 @@ class Importmap::Npm
   def packages_with_versions
     # We cannot use the name after "pin" because some dependencies are loaded from inside packages
     # Eg. pin "buffer", to: "https://ga.jspm.io/npm:@jspm/core@2.0.0-beta.19/nodelibs/browser/buffer.js"
-    with_versions = importmap.scan(/^pin .*(?<=npm:|npm\/|skypack\.dev\/|unpkg\.com\/)(.*)(?=@\d+\.\d+\.\d+)@(\d+\.\d+\.\d+(?:[^\/\s["']]*)).*$/) |
+    with_versions = importmap.scan(/^pin .*(?<=npm:|npm\/|skypack\.dev\/|unpkg\.com\/)([^@\/]+)@(\d+\.\d+\.\d+(?:[^\/\s"']*))/) |
       importmap.scan(/#{PIN_REGEX} #.*@(\d+\.\d+\.\d+(?:[^\s]*)).*$/)
 
     vendored_packages_without_version(with_versions).each do |package, path|

--- a/lib/importmap/npm.rb
+++ b/lib/importmap/npm.rb
@@ -17,7 +17,7 @@ class Importmap::Npm
   end
 
   def outdated_packages
-    packages_with_versions.each.with_object([]) do |(package, current_version), outdated_packages|
+    packages_with_versions.each_with_object([]) do |(package, current_version), outdated_packages|
       outdated_package = OutdatedPackage.new(name: package, current_version: current_version)
 
       if !(response = get_package(package))

--- a/lib/importmap/npm.rb
+++ b/lib/importmap/npm.rb
@@ -147,7 +147,7 @@ class Importmap::Npm
     end
 
     def find_unversioned_vendored_package(line, versioned_packages)
-      regexp = line.include?("to:")? /#{PIN_REGEX}to: ["']([^["']]*)["'].*/ : PIN_REGEX
+      regexp = line.include?("to:")? /#{PIN_REGEX}to: ["']([^"']*)["'].*/ : PIN_REGEX
       match = line.match(regexp)
 
       return unless match

--- a/lib/importmap/packager.rb
+++ b/lib/importmap/packager.rb
@@ -3,6 +3,8 @@ require "uri"
 require "json"
 
 class Importmap::Packager
+  PIN_REGEX = /#{Importmap::Map::PIN_REGEX}(.*)/.freeze # :nodoc:
+
   Error        = Class.new(StandardError)
   HTTPError    = Class.new(Error)
   ServiceError = Error.new(Error)
@@ -51,7 +53,7 @@ class Importmap::Packager
   end
 
   def packaged?(package)
-    importmap.match(/^pin ["']#{package}["'].*$/)
+    importmap.match(Importmap::Map.pin_line_regexp_for(package))
   end
 
   def download(package, url)
@@ -129,7 +131,7 @@ class Importmap::Packager
 
     def remove_package_from_importmap(package)
       all_lines = File.readlines(@importmap_path)
-      with_lines_removed = all_lines.grep_v(/pin ["']#{package}["']/)
+      with_lines_removed = all_lines.grep_v(Importmap::Map.pin_line_regexp_for(package))
 
       File.open(@importmap_path, "w") do |file|
         with_lines_removed.each { |line| file.write(line) }


### PR DESCRIPTION
The only option that is relevant to keep is the `preload` option.

Not all cases are kept though. If the option is set to a variable or complex expression, it is not kept. Only simple values like `true`, `false`, or a string/array of strings are preserved.

Fixes #307