### PR TITLE
Inaccurate warning for ignoring vendored packages with subpath and version

### DIFF
--- a/lib/importmap/npm.rb
+++ b/lib/importmap/npm.rb
@@ -170,7 +170,7 @@ class Importmap::Npm
       package, filename = match.captures
       filename ||= "#{package}.js"
 
-      return if versioned_packages.include?(package)
+      return if versioned_packages.include?(extract_base_package_name(package))
 
       path = File.join(@vendor_path, filename)
       [package, path] if File.exist?(path)

--- a/test/fixtures/files/vendored_subpath_with_version_comment_import_map.rb
+++ b/test/fixtures/files/vendored_subpath_with_version_comment_import_map.rb
@@ -1,0 +1,1 @@
+pin "pdfjs-dist/build/pdf.min.mjs", to: "pdfjs-dist--build--pdf.min.mjs.js" # @5.4.530

--- a/test/npm_test.rb
+++ b/test/npm_test.rb
@@ -114,6 +114,19 @@ class Importmap::NpmTest < ActiveSupport::TestCase
     end
   end
 
+  test "does not warn for vendored packages with subpath and version comment" do
+    Dir.mktmpdir do |vendor_path|
+      create_vendored_file(vendor_path, "pdfjs-dist--build--pdf.min.mjs.js")
+      npm = Importmap::Npm.new(file_fixture("vendored_subpath_with_version_comment_import_map.rb"), vendor_path: vendor_path)
+
+      outdated_packages = []
+      stdout, _stderr = capture_io { outdated_packages = npm.outdated_packages }
+
+      assert_equal("", stdout)
+      assert_equal(0, outdated_packages.size)
+    end
+  end
+
   test "failed outdated packages request with error response" do
     client = Minitest::Mock.new
     response = Class.new do


### PR DESCRIPTION
I noticed a warning that a couple of my vendored packages were being ignored as though there were unversioned:
```
pin "pdfjs-dist/build/pdf.min.mjs", to: "pdfjs-dist--build--pdf.min.mjs.js" # @5.4.530
pin "pdfjs-dist/build/pdf.worker.min.mjs", to: "pdfjs-dist--build--pdf.worker.min.mjs.js" # @5.4.530
```

For example, when executing `bin/importmap audit`:
```
$ bin/importmap audit
Ignoring pdfjs-dist/build/pdf.min.mjs (vendor/javascript/pdfjs-dist--build--pdf.min.mjs.js) since no version is specified in the importmap
Ignoring pdfjs-dist/build/pdf.worker.min.mjs (vendor/javascript/pdfjs-dist--build--pdf.worker.min.mjs.js) since no version is specified in the importmap
```

This PR makes a change to use the `extract_base_package_name()` method within `find_unversioned_vendored_package()` to make it consistent with `packages_with_versions()` and eliminate the erroneous warning.

I also created a new test to confirm that there is no longer a warning emitted.

@rafaelfranca please let me know if you prefer a different approach.