### PR TITLE
Don't crash on `bin/importmap pin` with no arguments

### DIFF
--- a/lib/importmap/commands.rb
+++ b/lib/importmap/commands.rb
@@ -179,7 +179,7 @@ class Importmap::Commands < Thor
     def for_each_import(packages, **options, &block)
       response = packager.import(*packages, **options)
 
-      if response
+      if response && response[:imports].present?
         response[:imports].each(&block)
       else
         handle_package_not_found(packages, options[:from])

--- a/test/commands_test.rb
+++ b/test/commands_test.rb
@@ -20,6 +20,12 @@ class CommandsTest < ActiveSupport::TestCase
     assert_includes JSON.parse(out), "imports"
   end
 
+  test "pin command without arguments does not raise" do
+    out, _err = run_importmap_command("pin")
+
+    assert_includes out, "Couldn't find any packages"
+  end
+
   test "update command prints message of no outdated packages" do
     out, _err = run_importmap_command("update")
 


### PR DESCRIPTION
## What

`bin/importmap pin` with no package arguments raised `NoMethodError: undefined method 'each' for nil` instead of printing a friendly message.

## Why

On a `pin` with no packages, the JSPM service returns a `200` whose body has no `map.imports`. `Importmap::Packager#extract_parsed_response` builds `{ imports: parsed.dig("map", "imports") }`, so the result is a truthy hash whose `:imports` value is `nil`. `Importmap::Commands#for_each_import` only guarded against a nil `response`, so the truthy hash sailed past the `if response` check straight into `nil.each` and crashed.

## How

Tighten the guard from `if response` to `if response && response[:imports].present?`. An empty/missing-imports result now routes through the existing `handle_package_not_found`, giving the same UX as pinning an unknown package. This is consistent with the `.blank?` usage already present in that method, and stays a single line.

I considered the alternative of returning `nil` from `extract_parsed_response` when `imports` is nil (pushing the guard down to where the `{ imports: nil }` shape is constructed). I kept the guard at the call site since `for_each_import` is the only consumer and the one-line check reads clearly there, but I'm happy to move it if preferred.

## Test

Added a regression test in the existing house style (real `bin/importmap pin` subprocess against live jspm.io, matching the `md5@2.2.0`/`pristine` tests) asserting the no-arg invocation prints `Couldn't find any packages` instead of raising. It fails on `main` with the `NoMethodError` and passes with this patch.

Fixes #317