### PR TITLE
Respect remote URL pins and preserve pin options in bin/importmap

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    importmap-rails (2.2.2)
+    importmap-rails (2.2.3)
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
       railties (>= 6.0.0)
@@ -255,6 +255,7 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-20
   x86_64-darwin-21
   x86_64-darwin-22

--- a/README.md
+++ b/README.md
@@ -137,6 +137,25 @@ If you later wish to remove a downloaded pin:
 Unpinning and removing "react"
 ```
 
+### Pinning to remote CDN URLs
+
+If you'd rather load a package straight from the CDN instead of vendoring a download, pass `--remote`:
+
+```bash
+./bin/importmap pin react --remote
+Pinning "react" to https://ga.jspm.io/npm:react@19.1.0/index.js
+```
+
+This will produce a pin in your `config/importmap.rb` like so:
+
+```ruby
+pin "react", to: "https://ga.jspm.io/npm:react@19.1.0/index.js"
+```
+
+Remote pins are respected from then on — no `--remote` flag needed. When a remote-pinned package is pinned again or picked up by `./bin/importmap update` (whether directly or as a dependency of another package), the pin stays remote: the URL is re-resolved from the same CDN provider it already points to (`ga.jspm.io`, `unpkg.com`, `cdn.jsdelivr.net`, `cdn.skypack.dev`, or `esm.sh`) instead of being replaced with a download. Pins pointing at any other host are left completely untouched and reported as skipped, and `./bin/importmap pristine` skips remote pins since there is nothing to redownload.
+
+Options on existing pins, like `preload: false`, are preserved when a pin is rewritten. An explicit `integrity:` value is dropped when the URL changes, since the old hash would no longer match — see the SRI section below for pinning fresh integrity hashes.
+
 ## Subresource Integrity (SRI)
 
 For enhanced security, importmap-rails supports [Subresource Integrity (SRI)](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) hashes for packages loaded from external CDNs.

--- a/lib/importmap/commands.rb
+++ b/lib/importmap/commands.rb
@@ -13,9 +13,10 @@ class Importmap::Commands < Thor
   option :env, type: :string, aliases: :e, default: "production"
   option :from, type: :string, aliases: :f, default: "jspm"
   option :preload, type: :string, repeatable: true, desc: "Can be used multiple times"
+  option :remote, type: :boolean, default: false, desc: "Pin to the remote URL instead of vendoring a download"
   def pin(*packages)
     for_each_import(packages, env: options[:env], from: options[:from]) do |package, url|
-      pin_package(package, url, options[:preload])
+      pin_package(package, url, preload: options[:preload], remote: options[:remote], env: options[:env])
     end
   end
 
@@ -38,9 +39,13 @@ class Importmap::Commands < Thor
     packages = prepare_packages_with_versions
 
     for_each_import(packages, env: options[:env], from: options[:from]) do |package, url|
-      puts %(Downloading "#{package}" to #{packager.vendor_path}/#{package}.js from #{url})
+      if packager.remote_pin?(package)
+        puts %(Skipping "#{package}" (pinned to remote URL))
+      else
+        puts %(Downloading "#{package}" to #{packager.vendor_path}/#{package}.js from #{url})
 
-      packager.download(package, url)
+        packager.download(package, url)
+      end
     end
   end
 
@@ -90,13 +95,8 @@ class Importmap::Commands < Thor
   desc "update", "Update outdated package pins"
   def update
     if (outdated_packages = npm.outdated_packages).any?
-      package_names = outdated_packages.map(&:name)
-      packages_with_options = packager.extract_existing_pin_options(package_names)
-
-      for_each_import(package_names, env: "production", from: "jspm") do |package, url|
-        options = packages_with_options[package] || {}
-
-        pin_package(package, url, options[:preload])
+      for_each_import(outdated_packages.map(&:name), env: "production", from: "jspm") do |package, url|
+        pin_package(package, url)
       end
     else
       puts "No outdated packages found"
@@ -117,14 +117,58 @@ class Importmap::Commands < Thor
       @npm ||= Importmap::Npm.new
     end
 
-    def pin_package(package, url, preload)
+    def pin_package(package, url, preload: nil, remote: false, env: "production")
+      existing_options = packager.extract_existing_pin_options(package)[package] || {}
+      preload = existing_options[:preload] if preload.nil?
+      existing_url = existing_options[:to] if existing_options[:to].to_s.match?(Importmap::Packager::REMOTE_URL_REGEXP)
+
+      if existing_url
+        repin_remote_package(package, url, existing_url, preload, env: env)
+      elsif remote
+        pin_remote_package(package, url, preload)
+      else
+        pin_vendored_package(package, url, preload)
+      end
+    end
+
+    def pin_vendored_package(package, url, preload)
       puts %(Pinning "#{package}" to #{packager.vendor_path}/#{package}.js via download from #{url})
 
       packager.download(package, url)
 
-      pin = packager.vendored_pin_for(package, url, preload)
+      update_importmap_with_pin(package, packager.vendored_pin_for(package, url, preload))
+    end
 
-      update_importmap_with_pin(package, pin)
+    def pin_remote_package(package, url, preload)
+      puts %(Pinning "#{package}" to #{url})
+
+      packager.remove_existing_package_file(package)
+
+      update_importmap_with_pin(package, packager.pin_for(package, url, preloads: preload))
+    end
+
+    def repin_remote_package(package, url, existing_url, preload, env:)
+      provider = packager.provider_for_url(existing_url)
+
+      if provider.nil?
+        puts %(Skipping "#{package}" pinned to custom URL #{existing_url})
+      elsif provider == packager.provider_for_url(url)
+        pin_remote_package(package, url, preload)
+      elsif (provider_url = resolve_url_from_provider(package, url, provider, env: env))
+        pin_remote_package(package, provider_url, preload)
+      else
+        puts %(Keeping "#{package}" pinned to #{existing_url} (couldn't resolve it from #{provider}))
+      end
+    end
+
+    def resolve_url_from_provider(package, reference_url, provider, env:)
+      version  = packager.extract_package_version_from(reference_url)
+      response = packager.import("#{package}#{version}", env: env, from: provider)
+
+      response && response[:imports][package]
+    rescue Importmap::Packager::Error => error
+      puts %(Failed to resolve "#{package}" from #{provider}: #{error.message})
+      nil
     end
 
     def update_importmap_with_pin(package, pin)

--- a/lib/importmap/npm.rb
+++ b/lib/importmap/npm.rb
@@ -51,7 +51,7 @@ class Importmap::Npm
   def packages_with_versions
     # We cannot use the name after "pin" because some dependencies are loaded from inside packages
     # Eg. pin "buffer", to: "https://ga.jspm.io/npm:@jspm/core@2.0.0-beta.19/nodelibs/browser/buffer.js"
-    with_versions = importmap.scan(/^pin .*(?<=npm:|npm\/|skypack\.dev\/|unpkg\.com\/)([^@\/]+)@(\d+\.\d+\.\d+(?:[^\/\s"']*))/) |
+    with_versions = importmap.scan(/^pin .*(?<=npm:|npm\/|skypack\.dev\/|unpkg\.com\/|esm\.sh\/|esm\.sh\/\*)([^@\/]+)@(\d+\.\d+\.\d+(?:[^\/\s"']*))/) |
       importmap.scan(/#{PIN_REGEX} #.*@(\d+\.\d+\.\d+(?:[^\s]*)).*$/)
 
     with_versions.map! do |package, version|

--- a/lib/importmap/packager.rb
+++ b/lib/importmap/packager.rb
@@ -5,6 +5,16 @@ require "json"
 class Importmap::Packager
   PIN_REGEX = /#{Importmap::Map::PIN_REGEX}(.*)/.freeze # :nodoc:
   PRELOAD_OPTION_REGEXP = /preload:\s*(\[[^\]]+\]|true|false|["'][^"']*["'])/.freeze # :nodoc:
+  TO_OPTION_REGEXP = /to:\s*["']([^"']*)["']/.freeze # :nodoc:
+  REMOTE_URL_REGEXP = %r{\Ahttps?://}.freeze # :nodoc:
+
+  PROVIDER_HOSTS = {
+    "ga.jspm.io"       => "jspm.io",
+    "unpkg.com"        => "unpkg",
+    "cdn.jsdelivr.net" => "jsdelivr",
+    "cdn.skypack.dev"  => "skypack",
+    "esm.sh"           => "esm.sh"
+  }.freeze # :nodoc:
 
   Error        = Class.new(StandardError)
   HTTPError    = Class.new(Error)
@@ -80,6 +90,25 @@ class Importmap::Packager
     end
   end
 
+  def remote_pin?(package)
+    options = extract_existing_pin_options(package)[package] || {}
+    options[:to].to_s.match?(REMOTE_URL_REGEXP)
+  end
+
+  def provider_for_url(url)
+    PROVIDER_HOSTS[URI(url.to_s).host]
+  rescue URI::InvalidURIError
+    nil
+  end
+
+  def remove_existing_package_file(package)
+    FileUtils.rm_rf vendored_package_path(package)
+  end
+
+  def extract_package_version_from(url)
+    url.match(/@\d+\.\d+\.\d+[^\/\s"']*/)&.to_a&.first
+  end
+
   private
     def build_package_options_lookup(lines)
       lines.each_with_object({}) do |line, package_options|
@@ -89,12 +118,17 @@ class Importmap::Packager
           package_name = match[1]
           options_part = match[2]
 
-          preload_match = options_part.match(PRELOAD_OPTION_REGEXP)
+          options = {}
 
-          if preload_match
-            preload = preload_from_string(preload_match[1])
-            package_options[package_name] = { preload: preload }
+          if (preload_match = options_part.match(PRELOAD_OPTION_REGEXP))
+            options[:preload] = preload_from_string(preload_match[1])
           end
+
+          if (to_match = options_part.match(TO_OPTION_REGEXP))
+            options[:to] = to_match[1]
+          end
+
+          package_options[package_name] = options if options.any?
         end
       end
     end
@@ -169,10 +203,6 @@ class Importmap::Packager
       FileUtils.mkdir_p @vendor_path
     end
 
-    def remove_existing_package_file(package)
-      FileUtils.rm_rf vendored_package_path(package)
-    end
-
     def remove_package_from_importmap(package)
       all_lines = File.readlines(@importmap_path)
       with_lines_removed = all_lines.grep_v(Importmap::Map.pin_line_regexp_for(package))
@@ -210,9 +240,5 @@ class Importmap::Packager
 
     def package_filename(package)
       package.gsub("/", "--") + ".js"
-    end
-
-    def extract_package_version_from(url)
-      url.match(/@\d+\.\d+\.\d+/)&.to_a&.first
     end
 end

--- a/test/commands_test.rb
+++ b/test/commands_test.rb
@@ -35,7 +35,7 @@ class CommandsTest < ActiveSupport::TestCase
   end
 
   test "pristine command redownloads all pinned packages" do
-    FileUtils.cp("#{__dir__}/fixtures/files/outdated_import_map.rb", "#{@tmpdir}/dummy/config/importmap.rb")
+    importmap_config("")
 
     out, _err = run_importmap_command("pin", "md5@2.2.0")
 
@@ -51,41 +51,42 @@ class CommandsTest < ActiveSupport::TestCase
   end
 
   test "update command preserves preload false option" do
-    importmap_config('pin "md5", to: "https://cdn.skypack.dev/md5@2.2.0", preload: false')
+    importmap_config('pin "md5", to: "https://cdn.jsdelivr.net/npm/md5@2.2.0/md5.js", preload: false')
 
     out, _err = run_importmap_command("update")
 
     assert_includes out, "Pinning"
 
     updated_content = File.read("#{@tmpdir}/dummy/config/importmap.rb")
-    assert_includes updated_content, "preload: false"
-    assert_includes updated_content, "# @2.3.0"
+    assert_includes updated_content, 'pin "md5", to: "https://cdn.jsdelivr.net/npm/md5@2.3.0/md5.js", preload: false'
+    assert_not_includes updated_content, "md5@2.2.0"
+    assert_not File.exist?("#{@tmpdir}/dummy/vendor/javascript/md5.js")
   end
 
   test "update command preserves preload true option" do
-    importmap_config('pin "md5", to: "https://cdn.skypack.dev/md5@2.2.0", preload: true')
+    importmap_config('pin "md5", to: "https://cdn.jsdelivr.net/npm/md5@2.2.0/md5.js", preload: true')
 
     out, _err = run_importmap_command("update")
 
     assert_includes out, "Pinning"
 
     updated_content = File.read("#{@tmpdir}/dummy/config/importmap.rb")
-    assert_includes updated_content, "preload: true"
+    assert_includes updated_content, 'pin "md5", to: "https://cdn.jsdelivr.net/npm/md5@2.3.0/md5.js", preload: true'
   end
 
   test "update command preserves custom preload string option" do
-    importmap_config('pin "md5", to: "https://cdn.skypack.dev/md5@2.2.0", preload: "custom"')
+    importmap_config('pin "md5", to: "https://cdn.jsdelivr.net/npm/md5@2.2.0/md5.js", preload: "custom"')
 
     out, _err = run_importmap_command("update")
 
     assert_includes out, "Pinning"
 
     updated_content = File.read("#{@tmpdir}/dummy/config/importmap.rb")
-    assert_includes updated_content, 'preload: "custom"'
+    assert_includes updated_content, 'pin "md5", to: "https://cdn.jsdelivr.net/npm/md5@2.3.0/md5.js", preload: "custom"'
   end
 
   test "update command removes existing integrity" do
-    importmap_config('pin "md5", to: "https://cdn.skypack.dev/md5@2.2.0", integrity: "sha384-oldintegrity"')
+    importmap_config('pin "md5", to: "https://cdn.jsdelivr.net/npm/md5@2.2.0/md5.js", integrity: "sha384-oldintegrity"')
 
     out, _err = run_importmap_command("update")
 
@@ -95,21 +96,20 @@ class CommandsTest < ActiveSupport::TestCase
     assert_not_includes updated_content, "integrity:"
   end
 
-  test "update command only keeps preload option" do
-    importmap_config('pin "md5", to: "https://cdn.skypack.dev/md5@2.2.0", preload: false, integrity: "sha384-oldintegrity"')
+  test "update command keeps pin remote and preload option but drops integrity" do
+    importmap_config('pin "md5", to: "https://cdn.jsdelivr.net/npm/md5@2.2.0/md5.js", preload: false, integrity: "sha384-oldintegrity"')
 
     out, _err = run_importmap_command("update")
 
     assert_includes out, "Pinning"
 
     updated_content = File.read("#{@tmpdir}/dummy/config/importmap.rb")
-    assert_includes updated_content, "preload: false"
-    assert_not_includes updated_content, "to:"
+    assert_includes updated_content, 'pin "md5", to: "https://cdn.jsdelivr.net/npm/md5@2.3.0/md5.js", preload: false'
     assert_not_includes updated_content, "integrity:"
   end
 
   test "update command handles packages with different quote styles" do
-    importmap_config("pin 'md5', to: 'https://cdn.skypack.dev/md5@2.2.0', preload: false")
+    importmap_config("pin 'md5', to: 'https://cdn.jsdelivr.net/npm/md5@2.2.0/md5.js', preload: false")
 
     out, _err = run_importmap_command("update")
 
@@ -117,10 +117,11 @@ class CommandsTest < ActiveSupport::TestCase
 
     updated_content = File.read("#{@tmpdir}/dummy/config/importmap.rb")
     assert_includes updated_content, "preload: false"
+    assert_includes updated_content, "md5@2.3.0"
   end
 
   test "update command preserves options with version comments" do
-    importmap_config('pin "md5", to: "https://cdn.skypack.dev/md5@2.2.0", preload: false # @2.2.0')
+    importmap_config('pin "md5", to: "https://cdn.jsdelivr.net/npm/md5@2.2.0/md5.js", preload: false # @2.2.0')
 
     out, _err = run_importmap_command("update")
 
@@ -128,12 +129,12 @@ class CommandsTest < ActiveSupport::TestCase
 
     updated_content = File.read("#{@tmpdir}/dummy/config/importmap.rb")
     assert_includes updated_content, "preload: false"
-    assert_includes updated_content, "# @2.3.0"
-    assert_not_includes updated_content, "# @2.2.0"
+    assert_includes updated_content, "md5@2.3.0"
+    assert_not_includes updated_content, "2.2.0"
   end
 
   test "update command handles whitespace variations in pin options" do
-    importmap_config('pin "md5",   to:  "https://cdn.skypack.dev/md5@2.2.0",  preload:  false   ')
+    importmap_config('pin "md5",   to:  "https://cdn.jsdelivr.net/npm/md5@2.2.0/md5.js",  preload:  false   ')
 
     out, _err = run_importmap_command("update")
 
@@ -142,6 +143,77 @@ class CommandsTest < ActiveSupport::TestCase
     updated_content = File.read("#{@tmpdir}/dummy/config/importmap.rb")
     assert_equal 4, updated_content.lines.size
     assert_includes updated_content, "preload: false"
+  end
+
+  test "pin command with --remote pins to the resolved URL without downloading" do
+    importmap_config("")
+
+    out, _err = run_importmap_command("pin", "md5@2.2.0", "--remote")
+
+    assert_includes out, 'Pinning "md5" to https://ga.jspm.io/npm:md5@2.2.0/md5.js'
+
+    content = File.read("#{@tmpdir}/dummy/config/importmap.rb")
+    assert_includes content, 'pin "md5", to: "https://ga.jspm.io/npm:md5@2.2.0/md5.js"'
+    assert_not File.exist?("#{@tmpdir}/dummy/vendor/javascript/md5.js")
+  end
+
+  test "pin command with --remote converts a vendored pin and removes the vendored file" do
+    importmap_config("")
+
+    run_importmap_command("pin", "md5@2.2.0")
+    assert File.exist?("#{@tmpdir}/dummy/vendor/javascript/md5.js")
+
+    run_importmap_command("pin", "md5@2.2.0", "--remote")
+
+    content = File.read("#{@tmpdir}/dummy/config/importmap.rb")
+    assert_includes content, 'pin "md5", to: "https://ga.jspm.io/npm:md5@2.2.0/md5.js"'
+    assert_not File.exist?("#{@tmpdir}/dummy/vendor/javascript/md5.js")
+  end
+
+  test "pin command respects an existing remote pin and updates its URL" do
+    importmap_config('pin "md5", to: "https://ga.jspm.io/npm:md5@2.2.0/md5.js", preload: false')
+
+    out, _err = run_importmap_command("pin", "md5@2.3.0")
+
+    assert_includes out, 'Pinning "md5" to https://ga.jspm.io/npm:md5@2.3.0/md5.js'
+
+    content = File.read("#{@tmpdir}/dummy/config/importmap.rb")
+    assert_includes content, 'pin "md5", to: "https://ga.jspm.io/npm:md5@2.3.0/md5.js", preload: false'
+    assert_not File.exist?("#{@tmpdir}/dummy/vendor/javascript/md5.js")
+  end
+
+  test "pin command does not clobber options of dependency pins" do
+    importmap_config(<<~PINS)
+      pin "charenc", to: "https://ga.jspm.io/npm:charenc@0.0.2/charenc.js", preload: false
+      pin "crypt", preload: false # @0.0.2
+    PINS
+
+    run_importmap_command("pin", "md5@2.3.0")
+
+    content = File.read("#{@tmpdir}/dummy/config/importmap.rb")
+    assert_includes content, 'pin "charenc", to: "https://ga.jspm.io/npm:charenc@0.0.2/charenc.js", preload: false'
+    assert_includes content, 'pin "crypt", preload: false # @0.0.2'
+  end
+
+  test "pin command leaves pins to custom URLs untouched" do
+    importmap_config('pin "md5", to: "https://cdn.example.com/md5.js", preload: false')
+
+    out, _err = run_importmap_command("pin", "md5@2.3.0")
+
+    assert_includes out, 'Skipping "md5" pinned to custom URL https://cdn.example.com/md5.js'
+
+    content = File.read("#{@tmpdir}/dummy/config/importmap.rb")
+    assert_includes content, 'pin "md5", to: "https://cdn.example.com/md5.js", preload: false'
+    assert_not File.exist?("#{@tmpdir}/dummy/vendor/javascript/md5.js")
+  end
+
+  test "pristine command skips packages pinned to remote URLs" do
+    importmap_config('pin "md5", to: "https://ga.jspm.io/npm:md5@2.2.0/md5.js"')
+
+    out, _err = run_importmap_command("pristine")
+
+    assert_includes out, 'Skipping "md5" (pinned to remote URL)'
+    assert_not File.exist?("#{@tmpdir}/dummy/vendor/javascript/md5.js")
   end
 
   private

--- a/test/fixtures/files/outdated_import_map.rb
+++ b/test/fixtures/files/outdated_import_map.rb
@@ -1,1 +1,1 @@
-pin "md5", to: "https://cdn.skypack.dev/md5@2.2.0", preload: true
+pin "md5", to: "https://cdn.jsdelivr.net/npm/md5@2.2.0/md5.js", preload: true

--- a/test/packager_test.rb
+++ b/test/packager_test.rb
@@ -122,7 +122,7 @@ class Importmap::PackagerTest < ActiveSupport::TestCase
 
     options = extract_options_for_package(packager, "package1")
 
-    assert_equal({}, options)
+    assert_equal({ to: "custom_path.js" }, options)
   end
 
   test "extract_existing_pin_options with integrity option only" do
@@ -140,7 +140,16 @@ class Importmap::PackagerTest < ActiveSupport::TestCase
 
     options = extract_options_for_package(packager, "package1")
 
-    assert_equal({ preload: false }, options)
+    assert_equal({ preload: false, to: "path.js" }, options)
+  end
+
+  test "extract_existing_pin_options with remote to option" do
+    temp_importmap = create_temp_importmap('pin "package1", to: "https://ga.jspm.io/npm:package1@1.0.0/index.js", preload: false')
+    packager = Importmap::Packager.new(temp_importmap)
+
+    options = extract_options_for_package(packager, "package1")
+
+    assert_equal({ preload: false, to: "https://ga.jspm.io/npm:package1@1.0.0/index.js" }, options)
   end
 
   test "extract_existing_pin_options with version comment" do
@@ -197,6 +206,38 @@ class Importmap::PackagerTest < ActiveSupport::TestCase
       "package4" => {},
       "nonexistent" => {}
     }, result)
+  end
+
+  test "remote_pin?" do
+    temp_importmap = create_temp_importmap(<<~PINS)
+      pin "remote", to: "https://ga.jspm.io/npm:remote@1.0.0/index.js"
+      pin 'single', to: 'https://cdn.jsdelivr.net/npm/single@1.0.0/index.js'
+      pin "local", to: "local.js"
+      pin "bare"
+    PINS
+    packager = Importmap::Packager.new(temp_importmap)
+
+    assert packager.remote_pin?("remote")
+    assert packager.remote_pin?("single")
+    assert_not packager.remote_pin?("local")
+    assert_not packager.remote_pin?("bare")
+    assert_not packager.remote_pin?("missing")
+  end
+
+  test "provider_for_url" do
+    assert_equal "jspm.io", @packager.provider_for_url("https://ga.jspm.io/npm:md5@2.3.0/md5.js")
+    assert_equal "unpkg", @packager.provider_for_url("https://unpkg.com/md5@2.3.0/md5.js")
+    assert_equal "jsdelivr", @packager.provider_for_url("https://cdn.jsdelivr.net/npm/md5@2.3.0/md5.js")
+    assert_equal "skypack", @packager.provider_for_url("https://cdn.skypack.dev/md5@2.3.0")
+    assert_equal "esm.sh", @packager.provider_for_url("https://esm.sh/*md5@2.3.0/md5.js")
+    assert_nil @packager.provider_for_url("https://cdn.example.com/md5.js")
+    assert_nil @packager.provider_for_url("not a url")
+  end
+
+  test "extract_package_version_from" do
+    assert_equal "@17.0.2", @packager.extract_package_version_from("https://cdn/react@17.0.2")
+    assert_equal "@2.0.0-beta.19", @packager.extract_package_version_from("https://ga.jspm.io/npm:@jspm/core@2.0.0-beta.19/nodelibs/browser/buffer.js")
+    assert_nil @packager.extract_package_version_from("https://cdn/react")
   end
 
   private


### PR DESCRIPTION
## Problem

Running `bin/importmap pin pkg@x.y.z` (or `update`) rewrites every pin in the jspm response — including transitive dependencies — from scratch:

1. **`preload: false` is wiped on every bump.** The new pin line is built solely from the CLI's `--preload` flag, so options on existing pins (and on every dependency that happens to be in the response) are lost. `update` preserved preload for directly-requested packages, but `pin` never did, and dependencies were always clobbered.
2. **Hand-written remote URL pins are replaced with downloads.** A pin like `pin "pkg", to: "https://ga.jspm.io/npm:pkg@1.0.0/index.js"` is silently converted to a vendored download the next time the package is pinned, updated, or pulled in as a dependency.

## Changes

`pin_package` now looks at the existing pin before writing:

- **Options are preserved on rewrite.** The existing pin's `preload` value survives `pin`/`update` unless `--preload` is passed explicitly. This applies to dependencies re-pinned along the way, not just requested packages.
- **Remote URL pins stay remote.** If the existing pin's `to:` is an `https://` URL:
  - Known CDN hosts (`ga.jspm.io`, `unpkg.com`, `cdn.jsdelivr.net`, `cdn.skypack.dev`, `esm.sh`) are re-resolved **from the same provider** at the new version — a jsdelivr pin updates to a new jsdelivr URL even though resolution goes through jspm.
  - Unknown/custom hosts are left completely untouched, with a `Skipping "pkg" pinned to custom URL ...` notice.
  - If the provider can't resolve the package (e.g. Skypack is no longer resolvable through the jspm generator), the existing pin is kept with a notice instead of being clobbered.
- **New `--remote` flag** on `pin` creates URL pins without downloading (`pin "react", to: "https://ga.jspm.io/npm:react@19.1.0/index.js"`), and removes the previously vendored file when converting an existing vendored pin.
- **`pristine` skips remote pins** — there is nothing to redownload.
- Supporting fixes: the npm version scan now recognizes `esm.sh` URLs (including its `*` external-deps prefix), and version extraction keeps prerelease suffixes (`@2.0.0-beta.19` no longer truncates to `@2.0.0`).

An explicit `integrity:` value is still dropped when a pin's URL changes (unchanged policy — the stale hash would break the page).

## Notes

- The test asserting that `update` strips `to:` from URL pins encoded exactly the behavior this fixes, so it is inverted; the Skypack test fixtures were moved to jsdelivr since Skypack no longer resolves through the generator.
- `Gemfile.lock` is synced with the 2.2.3 version bump from `Prepare for 2.2.3` (the lock still said 2.2.2) and picks up the `arm64-darwin-24` platform.
- README documents the new behavior under "Pinning to remote CDN URLs".

## Testing

Full suite passes: **112 runs, 0 failures**. The commands tests run `bin/importmap` as a subprocess against the live jspm API and assert on the resulting `config/importmap.rb`, covering: remote pins surviving `pin`/`update`, dependency options surviving a bump, `--remote` creation and vendored→remote conversion, custom-host pins left byte-identical, and `pristine` skipping remote pins.
