### PR TITLE
Warm cache and handle frozen import maps

### DIFF
--- a/lib/importmap/engine.rb
+++ b/lib/importmap/engine.rb
@@ -41,6 +41,20 @@ module Importmap
       end
     end
 
+    initializer "importmap.warm_cache" do |app|
+      if app.config.eager_load
+        app.config.after_initialize do
+          if defined?(ActionController::Base)
+            begin
+              app.importmap.warm_cache(resolver: ActionController::Base.helpers)
+            rescue => error
+              Rails.logger.warn "Unable to warm the importmap caches: #{error.message}"
+            end
+          end
+        end
+      end
+    end
+
     initializer "importmap.assets" do |app|
       if app.config.respond_to?(:assets)
         app.config.assets.paths << Rails.root.join("app/javascript")

--- a/lib/importmap/map.rb
+++ b/lib/importmap/map.rb
@@ -200,6 +200,8 @@ class Importmap::Map
     def cache_as(name)
       if result = @cache[name.to_s]
         result
+      elsif @cache.frozen?
+        yield
       else
         @cache[name.to_s] = yield
       end

--- a/lib/importmap/map.rb
+++ b/lib/importmap/map.rb
@@ -167,6 +167,18 @@ class Importmap::Map
     end
   end
 
+  # Precomputes the caches used by the view helpers: the JSON and, for each of the +entry_points+, the
+  # preloaded module packages under the cache key the helpers use. The results are then served from the
+  # cache even if the map is frozen afterwards, for example to share it between Ractors. By default,
+  # every entry point named in the map is warmed (see +known_entry_points+).
+  def warm_cache(resolver:, entry_points: known_entry_points)
+    entry_points.each do |entry_point|
+      preloaded_module_packages(resolver: resolver, entry_point: entry_point, cache_key: entry_point)
+    end
+    to_json(resolver: resolver)
+    self
+  end
+
   # Returns a SHA1 digest of the import map json that can be used as a part of a page etag to
   # ensure that a html cache is invalidated when the import map is changed.
   #
@@ -190,6 +202,15 @@ class Importmap::Map
         end
     else
       @cache_sweeper
+    end
+  end
+
+  # Returns the entry point names that produce distinct preload results: the default "application" plus
+  # every entry point named in a pin's +preload+ option. Other entry points all select only the pins
+  # preloaded everywhere.
+  def known_entry_points
+    ["application"] | (@packages.values + @directories.values).flat_map do |mapping|
+      mapping.preload.in?([true, false]) ? [] : Array(mapping.preload)
     end
   end
 

--- a/test/importmap_test.rb
+++ b/test/importmap_test.rb
@@ -245,6 +245,21 @@ class ImportmapTest < ActiveSupport::TestCase
     ActionController::Base.asset_host = nil
   end
 
+  test "known_entry_points collects the entry points named in preload options" do
+    assert_equal ["application", "alternate"], @importmap.known_entry_points
+  end
+
+  test "warm_cache precomputes the caches, serving a frozen importmap without resolving again" do
+    importmap = Importmap::Map.new.draw { pin "application", preload: true, integrity: false }
+    Ractor.make_shareable(importmap.warm_cache(resolver: ApplicationController.helpers))
+
+    json = importmap.to_json(resolver: nil)
+    paths = importmap.preloaded_module_paths(resolver: nil, cache_key: "application")
+
+    assert_match %r{assets/application-.*\.js}, json
+    assert_match %r{assets/application-.*\.js}, paths.to_s
+  end
+
   test "deep-frozen importmap still resolves, without caching" do
     importmap = Ractor.make_shareable(Importmap::Map.new.draw { pin "application", preload: true, integrity: false })
 

--- a/test/importmap_test.rb
+++ b/test/importmap_test.rb
@@ -245,6 +245,23 @@ class ImportmapTest < ActiveSupport::TestCase
     ActionController::Base.asset_host = nil
   end
 
+  test "deep-frozen importmap still resolves, without caching" do
+    importmap = Ractor.make_shareable(Importmap::Map.new.draw { pin "application", preload: true, integrity: false })
+
+    set_one = importmap.preloaded_module_paths(resolver: ApplicationController.helpers)
+    json_one = importmap.to_json(resolver: ApplicationController.helpers)
+
+    ActionController::Base.asset_host = "http://assets.example.com"
+
+    set_two = importmap.preloaded_module_paths(resolver: ActionController::Base.helpers)
+    json_two = importmap.to_json(resolver: ActionController::Base.helpers)
+
+    assert_not_equal set_one, set_two
+    assert_not_equal json_one, json_two
+  ensure
+    ActionController::Base.asset_host = nil
+  end
+
   test "all caches reset" do
     set_one = @importmap.preloaded_module_paths(resolver: ApplicationController.helpers, cache_key: "1").to_s
     set_two = @importmap.preloaded_module_paths(resolver: ApplicationController.helpers, cache_key: "2").to_s


### PR DESCRIPTION
This PR helps for Ractor support. The Rails application can then deep-freeze (`Ractor.make_shareable`) the application map at `Rails.application.importmap`, and it becomes usable from worker Ractors rendering views with the importmap helpers (at the cost of not caching the results anymore).

In addition to not raising an exception when the map is frozen, this also pre-warms the cache during boot for eager-loaded apps. This is helpful for any deployment using preforking.

Since we don't know exactly the list of all entry points, and to avoid adding a new configuration option, we use "application" and all the entry points mentioned as preload targets for the pins. That is if you use a string or array of strings in the preload option, they are all considered entry points.

For example in the README example:

```ruby
# config/importmap.rb
pin "@github/hotkey", to: "@github--hotkey.js", preload: 'application'
pin "md5", preload: ['application', 'alternate']

# app/views/layouts/application.html.erb
<%= javascript_importmap_tags 'alternate' %>

# will include the following link before the importmap is setup:
<link rel="modulepreload" href="/assets/javascript/md5.js">
...
```

This will pre-warm the cache for "application" and "alternate" automatically.

Let me know if you think we should add a configuration option in addition to that, which would allow pre-warming the cache for an entry point that is not explicitly listed but only used in a view/layout.